### PR TITLE
Add mechanical guardrails for AI-assisted development drift and claim verification

### DIFF
--- a/.agents/skills/complete/SKILL.md
+++ b/.agents/skills/complete/SKILL.md
@@ -68,6 +68,16 @@ Finish with a concise **How to try it** note for the completed feature. If the
 manual path is more than a couple of steps, tell the user to run `/try latest`;
 that command can read the archived feature after `current-feature.md` is reset.
 
+## Pull request guardrails
+
+If the project uses pull requests, make the PR description explain why the change
+is needed, what scope was intended, what commands proved it, and where the
+external review lives. Use `.github/pull_request_template.md` when present.
+
+Before merge, strict CI may require `blueprint/reviews/current-diff-review.md` to
+contain an external AI or human review of the current diff. Treat a placeholder
+or missing review as a blocker, not a paperwork issue.
+
 ## Rules
 
 - The feature is the unit of history: one squashed feature commit on main, even if

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -74,11 +74,17 @@ Work through the spec's build steps in order, one at a time. For each step:
    focused test then, or note why not. When a step's done-when is behavioral (a
    click, a download, a flow across screens), run `/check` to prove it against the
    running app rather than eyeballing it.
-5. **Iterate until it works.** If it fails or the user wants changes, revise the
+5. **Run guardrails for risky diffs.** If the step touches source, workflow,
+   planning, or review files, run
+   `pwsh scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode ci` when the
+   script exists. Treat failures as real blockers. Warnings about external review
+   mean the PR will need another AI or human review artifact before strict CI
+   passes.
+6. **Iterate until it works.** If it fails or the user wants changes, revise the
    step (re-prompt or hand-edit the code), show the updated diff, and re-test.
    Repeat until it works and the user approves. Nothing is committed until the
    user is happy with the step.
-6. **Mark it done, then prompt to move on.** Once the step is approved, check that
+7. **Mark it done, then prompt to move on.** Once the step is approved, check that
    step off (`- [x]`) in `blueprint/context/current-feature.md` so progress survives a context
    clear. Then offer a short choice, noting that checkpoints are optional since
    `/complete` makes the real feature-level commit. Use the current tool's short

--- a/.claude/skills/complete/SKILL.md
+++ b/.claude/skills/complete/SKILL.md
@@ -68,6 +68,16 @@ Finish with a concise **How to try it** note for the completed feature. If the
 manual path is more than a couple of steps, tell the user to run `/try latest`;
 that command can read the archived feature after `current-feature.md` is reset.
 
+## Pull request guardrails
+
+If the project uses pull requests, make the PR description explain why the change
+is needed, what scope was intended, what commands proved it, and where the
+external review lives. Use `.github/pull_request_template.md` when present.
+
+Before merge, strict CI may require `blueprint/reviews/current-diff-review.md` to
+contain an external AI or human review of the current diff. Treat a placeholder
+or missing review as a blocker, not a paperwork issue.
+
 ## Rules
 
 - The feature is the unit of history: one squashed feature commit on main, even if

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -74,11 +74,17 @@ Work through the spec's build steps in order, one at a time. For each step:
    focused test then, or note why not. When a step's done-when is behavioral (a
    click, a download, a flow across screens), run `/check` to prove it against the
    running app rather than eyeballing it.
-5. **Iterate until it works.** If it fails or the user wants changes, revise the
+5. **Run guardrails for risky diffs.** If the step touches source, workflow,
+   planning, or review files, run
+   `pwsh scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode ci` when the
+   script exists. Treat failures as real blockers. Warnings about external review
+   mean the PR will need another AI or human review artifact before strict CI
+   passes.
+6. **Iterate until it works.** If it fails or the user wants changes, revise the
    step (re-prompt or hand-edit the code), show the updated diff, and re-test.
    Repeat until it works and the user approves. Nothing is committed until the
    user is happy with the step.
-6. **Mark it done, then prompt to move on.** Once the step is approved, check that
+7. **Mark it done, then prompt to move on.** Once the step is approved, check that
    step off (`- [x]`) in `blueprint/context/current-feature.md` so progress survives a context
    clear. Then offer a short choice, noting that checkpoints are optional since
    `/complete` makes the real feature-level commit. Use the current tool's short

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Why This Is Needed
+
+Explain the user or maintenance problem this PR solves. Include why the change
+belongs now instead of later.
+
+## Scope
+
+- Planned feature or fix:
+- Files intentionally touched:
+- Files touched that may surprise reviewers:
+
+## Blueprint Guardrails
+
+- Current feature or fix spec:
+- Build command run:
+- Test command run:
+- Browser or CLI evidence:
+- External AI review artifact:
+
+## Drift And Shortcut Check
+
+- Architecture drift checked:
+- Scope creep checked:
+- Prop drilling or coupling checked:
+- Hallucinated or misleading claims checked:
+
+## Reviewer Notes
+
+List the most important reviewer risks first. If an external AI reviewer found
+issues, summarize them here and link to `blueprint/reviews/current-diff-review.md`.

--- a/.github/workflows/blueprint-guardrails.yml
+++ b/.github/workflows/blueprint-guardrails.yml
@@ -1,0 +1,53 @@
+name: Blueprint Guardrails
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  guardrails:
+    name: Diff, drift, and review gates
+    runs-on: ubuntu-latest
+    env:
+      BLUEPRINT_REQUIRE_EXTERNAL_AI_REVIEW: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Blueprint guardrails
+        shell: pwsh
+        run: |
+          ./scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode ci -BaseRef origin/${{ github.base_ref }} -Strict
+
+      - name: Check Markdown links for core Blueprint files
+        shell: pwsh
+        run: |
+          $required = @(
+            "AGENTS.md",
+            "blueprint/context/ai-interaction.md",
+            "blueprint/context/coding-standards.md",
+            "blueprint/guardrails/config.json",
+            "scripts/guardrails/Invoke-BlueprintGuardrails.ps1"
+          )
+          foreach ($file in $required) {
+            if (-not (Test-Path $file)) {
+              throw "Missing required Blueprint file: $file"
+            }
+          }
+
+  shellcheck-hooks:
+    name: Hook smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate hook templates are shell scripts
+        run: |
+          sh -n scripts/guardrails/hooks/pre-commit
+          sh -n scripts/guardrails/hooks/pre-push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,9 @@ For a standard Next.js project. Change or remove if you're using something else.
 - Build: `npm run build`
 - Production server: `npm run start`
 - Lint: `npm run lint`
+- Install guardrail hooks: `pwsh scripts/guardrails/Install-GitHooks.ps1`
+- Run guardrails locally: `pwsh scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode ci`
+- Request external AI review: `pwsh scripts/guardrails/Request-ExternalAiReview.ps1`
 
 Testing is opt-in. If this project does not already have a unit test runner, run
 `/tests` or `$tests` to add one and update this section with the real test

--- a/README.md
+++ b/README.md
@@ -171,6 +171,61 @@ In this repo, **the build loop** means:
 The loop is the control system. The AI can keep iterating, but only inside the
 current spec, with observable checks and review gates.
 
+## Mechanical guardrails
+
+The Blueprint ships with a scriptable enforcement layer in addition to the
+Markdown workflow. The goal is to catch problems that process instructions alone
+cannot reliably stop: architecture drift, hallucinated status claims, misleading
+summaries, unreviewed workflow edits, skipped verification, and shortcuts that a
+single agent session may take when it is trying to finish quickly.
+
+This layer is intentionally diff-based. It reads Git state first, then compares
+review files and agent claims against the actual changed files. Markdown remains
+useful as context and review evidence, but the checks do not trust the current
+chat or a self-reported "tests passed" line.
+
+| Layer | What it enforces |
+| ---- | ---- |
+| Local hooks | `pre-commit` and `pre-push` call the same guardrail runner against the current diff. |
+| CI | `.github/workflows/blueprint-guardrails.yml` runs strict diff checks on pull requests. |
+| External review | `BLUEPRINT_AI_REVIEW_CMD` can call another AI reviewer and write `blueprint/reviews/current-diff-review.md`. |
+| Claim checks | Optional `blueprint/reviews/agent-claims.md` is compared with the real changed files. |
+| PR template | Pull requests must explain why the change is needed, what drift was checked, and where review evidence lives. |
+
+The guardrails are designed to fail on objective problems and warn on heuristic
+signals:
+
+- **Blocks** - protected branch commits, source changes without an active spec,
+  source changes before the overview exists, placeholder external review in
+  strict CI, and claims that contradict the diff.
+- **Warnings** - workflow-file changes that need adapter symmetry review,
+  missing external review in local mode, and possible prop drilling.
+- **Strict CI** - turns the external review requirement into a hard PR gate and
+  can promote architecture heuristics to blockers.
+
+Install the local hooks:
+
+```powershell
+pwsh scripts/guardrails/Install-GitHooks.ps1
+```
+
+Run the guardrails manually:
+
+```powershell
+pwsh scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode ci
+```
+
+Generate an external review after configuring a reviewer command:
+
+```powershell
+$env:BLUEPRINT_AI_REVIEW_CMD = "your-reviewer-command"
+pwsh scripts/guardrails/Request-ExternalAiReview.ps1
+```
+
+The reviewer command receives the generated prompt file path as its first
+argument and writes Markdown to stdout. In CI, setting
+`BLUEPRINT_REQUIRE_EXTERNAL_AI_REVIEW=1` makes that review artifact a hard gate.
+
 The diagram shows the whole workflow. `/overview` happens after planning and only
 re-runs when the plans change; the repeating loop starts at `/feature`.
 

--- a/blueprint/context/ai-interaction.md
+++ b/blueprint/context/ai-interaction.md
@@ -59,28 +59,35 @@ something done.
    evidence. Run `/tests` first if the project needs a stack-native unit test
    runner added or normalized. See the Testing section of `coding-standards.md`
    for the gate.
-6. **Try manually (optional)** - Run `/try` when you want a human walkthrough:
+6. **Mechanical guardrails** - Local hooks and CI call
+   `scripts/guardrails/Invoke-BlueprintGuardrails.ps1` against the current diff.
+   These checks look for commits on protected branches, app changes without an
+   active spec, placeholder overview drift, missing external review evidence in
+   strict mode, misleading agent claims, workflow changes, and early prop-drilling
+   signals. Markdown review files are evidence only; the script compares them to
+   git state.
+7. **Try manually (optional)** - Run `/try` when you want a human walkthrough:
    what to start, where to go, what to click or run, what to expect, and what
    would count as wrong. `/check` proves behavior from the agent side; `/try`
    gives you the manual review path.
-7. **Audit (optional)** - Run `/audit` when you want a read-only code quality pass
+8. **Audit (optional)** - Run `/audit` when you want a read-only code quality pass
    before closing a feature or after a larger automated run. It checks for
    duplication, dead code, missing tests for logic, standards drift, and
    maintainability risks. Fixes still happen through `/implement` or `/fix`.
-8. **Iterate** - If it doesn't work or needs changes, re-prompt or hand-edit and
+9. **Iterate** - If it doesn't work or needs changes, re-prompt or hand-edit and
    re-test; repeat until it works, before moving on.
-9. **Checkpoint (optional)** - after an approved step `/implement` offers a quick
+10. **Checkpoint (optional)** - after an approved step `/implement` offers a quick
    choice (continue / commit a checkpoint / walk me through it / stop here) as a
    selectable popup, or in plain text when there's a lot to read first so it doesn't
    cover what you're reading. Checkpoints are optional cheap rollback points; "walk
    me through it" gives a deeper code explanation and loops back; `/complete` makes
    the real feature-level commit. Build and tests must pass before any commit.
-10. **Log** - `/complete` archives the spec to `blueprint/history/features/NN-name.md` (or
+11. **Log** - `/complete` archives the spec to `blueprint/history/features/NN-name.md` (or
    `blueprint/history/fixes/`), checks the feature off in `blueprint/build-plan.md`, and
    resets `blueprint/context/current-feature.md` to its stub.
-11. **Feature commit** - `/complete` stages everything on the branch (step work
+12. **Feature commit** - `/complete` stages everything on the branch (step work
    plus the logging changes) into one conventional feature commit.
-12. **Squash-merge** - `/complete` squash-merges the branch to main (explicit yes)
+13. **Squash-merge** - `/complete` squash-merges the branch to main (explicit yes)
     and deletes it, so the feature lands as one commit. Then it must ask
     separately before pushing main; merge approval does not approve a push.
 
@@ -138,3 +145,23 @@ Review AI-generated code periodically, especially for:
 - Performance (unnecessary re-renders, N+1 queries)
 - Logic errors (edge cases)
 - Patterns (matches existing codebase?)
+
+## Mechanical Guardrails
+
+The Blueprint includes optional local hooks and a CI workflow that enforce the
+diff-level workflow:
+
+- Install hooks with `pwsh scripts/guardrails/Install-GitHooks.ps1`.
+- Run the same checks locally with
+  `pwsh scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode ci`.
+- Generate an external AI review with
+  `pwsh scripts/guardrails/Request-ExternalAiReview.ps1` after setting
+  `BLUEPRINT_AI_REVIEW_CMD`.
+- CI sets `BLUEPRINT_REQUIRE_EXTERNAL_AI_REVIEW=1`, so pull requests need
+  `blueprint/reviews/current-diff-review.md` to contain a real review rather than
+  the placeholder.
+
+These scripts are intentionally diff-based. They do not trust the current chat.
+They compare review artifacts and agent claims against git state so shortcuts,
+hallucinated "tests passed" claims, scope drift, and unreviewed workflow changes
+show up before merge.

--- a/blueprint/guardrails/config.json
+++ b/blueprint/guardrails/config.json
@@ -1,0 +1,35 @@
+{
+  "protectedBranches": ["main", "master"],
+  "externalReview": {
+    "artifact": "blueprint/reviews/current-diff-review.md",
+    "commandEnv": "BLUEPRINT_AI_REVIEW_CMD",
+    "strictEnv": "BLUEPRINT_REQUIRE_EXTERNAL_AI_REVIEW"
+  },
+  "claimReport": {
+    "artifact": "blueprint/reviews/agent-claims.md"
+  },
+  "propDrilling": {
+    "maxPropsOnComponent": 8,
+    "repeatedPropThreshold": 3,
+    "failInStrictMode": true
+  },
+  "sourcePathPrefixes": [
+    "app/",
+    "src/",
+    "components/",
+    "pages/",
+    "lib/",
+    "server/",
+    "client/",
+    "api/",
+    "prisma/",
+    "db/"
+  ],
+  "workflowPathPrefixes": [
+    ".agents/",
+    ".claude/",
+    "blueprint/",
+    ".github/workflows/",
+    "scripts/guardrails/"
+  ]
+}

--- a/blueprint/reviews/README.md
+++ b/blueprint/reviews/README.md
@@ -1,0 +1,25 @@
+# Blueprint Reviews
+
+This directory stores review evidence produced outside the implementation
+session.
+
+## Files
+
+- `current-diff-review.md` - external AI or human review of the current diff.
+- `agent-claims.md` - optional structured claims from the implementing agent.
+
+These files are evidence, not source of truth. Scripts compare them against the
+actual diff and command output so an agent cannot claim a passing check or a
+small scope without evidence.
+
+## External AI review
+
+Set `BLUEPRINT_AI_REVIEW_CMD` to a command that accepts the review prompt on
+stdin and writes review markdown to stdout. Then run:
+
+```powershell
+pwsh scripts/guardrails/Request-ExternalAiReview.ps1
+```
+
+In CI, set `BLUEPRINT_REQUIRE_EXTERNAL_AI_REVIEW=1` to make the review artifact a
+hard gate for pull requests.

--- a/blueprint/reviews/agent-claims.md
+++ b/blueprint/reviews/agent-claims.md
@@ -1,0 +1,20 @@
+# Agent Claims
+
+> Optional structured report from the implementing agent. Guardrails treat this
+> as untrusted input and compare it with the actual diff.
+
+## Changed Files
+
+- 
+
+## Commands Claimed
+
+- 
+
+## Evidence Files
+
+- 
+
+## Completed Steps
+
+- 

--- a/blueprint/reviews/current-diff-review.md
+++ b/blueprint/reviews/current-diff-review.md
@@ -1,0 +1,36 @@
+# Current Diff Review
+
+> Replace this file with an external AI or human review before strict CI gates.
+> The guardrail scripts require the sections below when strict review is enabled.
+
+## Reviewer
+
+- Name:
+- Tool or model:
+- Date:
+
+## Diff Scope
+
+- Base:
+- Head:
+- Changed files reviewed:
+
+## Findings
+
+- None recorded yet.
+
+## Drift Check
+
+- Architecture drift:
+- Scope creep:
+- Standards drift:
+
+## Claim Check
+
+- Build/test claims verified:
+- Changed-file claims verified:
+- Risky shortcuts found:
+
+## Verdict
+
+Pending.

--- a/scripts/guardrails/Install-GitHooks.ps1
+++ b/scripts/guardrails/Install-GitHooks.ps1
@@ -1,0 +1,34 @@
+param(
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (& git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
+
+$hooksDir = Join-Path $repoRoot ".git/hooks"
+if (-not (Test-Path $hooksDir)) {
+    throw "Missing Git hooks directory: $hooksDir"
+}
+
+$templates = @{
+    "pre-commit" = "scripts/guardrails/hooks/pre-commit"
+    "pre-push" = "scripts/guardrails/hooks/pre-push"
+}
+
+foreach ($hookName in $templates.Keys) {
+    $target = Join-Path $hooksDir $hookName
+    $source = Join-Path $repoRoot $templates[$hookName]
+
+    if ((Test-Path $target) -and -not $Force) {
+        throw "Hook already exists: $target. Re-run with -Force to replace it."
+    }
+
+    Copy-Item $source $target -Force
+    if ($IsLinux -or $IsMacOS) {
+        & chmod +x $target
+    }
+    Write-Host "Installed $hookName hook."
+}
+
+Write-Host "Blueprint guardrail hooks installed."

--- a/scripts/guardrails/Invoke-BlueprintGuardrails.ps1
+++ b/scripts/guardrails/Invoke-BlueprintGuardrails.ps1
@@ -1,0 +1,279 @@
+param(
+    [ValidateSet("pre-commit", "pre-push", "ci")]
+    [string]$Mode = "ci",
+    [string]$BaseRef = "origin/main",
+    [switch]$Strict
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (& git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
+
+$configPath = Join-Path $repoRoot "blueprint/guardrails/config.json"
+if (-not (Test-Path $configPath)) {
+    throw "Missing guardrail config: $configPath"
+}
+
+$config = Get-Content $configPath -Raw | ConvertFrom-Json
+$failures = New-Object System.Collections.Generic.List[string]
+$warnings = New-Object System.Collections.Generic.List[string]
+
+function Add-Failure([string]$Message) {
+    $script:failures.Add($Message) | Out-Null
+}
+
+function Add-Warning([string]$Message) {
+    $script:warnings.Add($Message) | Out-Null
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Args
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $output = & git @Args 2>$null
+    $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $previousErrorActionPreference
+
+    if ($exitCode -ne 0) {
+        return $null
+    }
+    return $output
+}
+
+function Get-ChangedFiles {
+    if ($Mode -eq "pre-commit") {
+        $files = Invoke-Git -Args @("diff", "--cached", "--name-only", "--diff-filter=ACMR")
+    } else {
+        $mergeBase = Invoke-Git -Args @("merge-base", "HEAD", $BaseRef)
+        if (-not $mergeBase) {
+            $mergeBase = Invoke-Git -Args @("rev-parse", "HEAD~1")
+        }
+        if ($mergeBase) {
+            $files = Invoke-Git -Args @("diff", "--name-only", "--diff-filter=ACMR", "$mergeBase...HEAD")
+        } else {
+            $files = Invoke-Git -Args @("diff", "--name-only", "--diff-filter=ACMR", "HEAD")
+        }
+
+        $workingTreeFiles = Invoke-Git -Args @("diff", "--name-only", "--diff-filter=ACMR")
+        $stagedFiles = Invoke-Git -Args @("diff", "--cached", "--name-only", "--diff-filter=ACMR")
+        $untrackedFiles = Invoke-Git -Args @("ls-files", "--others", "--exclude-standard")
+        $files = @($files) + @($workingTreeFiles) + @($stagedFiles) + @($untrackedFiles)
+    }
+
+    if (-not $files) {
+        return @()
+    }
+
+    return @($files | Where-Object { $_ -and $_.Trim().Length -gt 0 } | ForEach-Object { $_.Replace("\", "/") } | Sort-Object -Unique)
+}
+
+function Test-PathPrefix([string]$Path, $Prefixes) {
+    foreach ($prefix in $Prefixes) {
+        if ($Path.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Get-DiffText {
+    if ($Mode -eq "pre-commit") {
+        $text = Invoke-Git -Args @("diff", "--cached", "--unified=0")
+    } else {
+        $mergeBase = Invoke-Git -Args @("merge-base", "HEAD", $BaseRef)
+        if ($mergeBase) {
+            $text = Invoke-Git -Args @("diff", "--unified=0", "$mergeBase...HEAD")
+        } else {
+            $text = Invoke-Git -Args @("diff", "--unified=0", "HEAD~1...HEAD")
+        }
+
+        $workingTreeText = Invoke-Git -Args @("diff", "--unified=0")
+        $stagedText = Invoke-Git -Args @("diff", "--cached", "--unified=0")
+        $text = @($text) + @($workingTreeText) + @($stagedText)
+    }
+
+    if (-not $text) {
+        return ""
+    }
+    return ($text -join "`n")
+}
+
+function Test-ReviewArtifact([string]$ArtifactPath) {
+    if (-not (Test-Path $ArtifactPath)) {
+        return $false
+    }
+
+    $review = Get-Content $ArtifactPath -Raw
+    $requiredSections = @(
+        "## Reviewer",
+        "## Diff Scope",
+        "## Findings",
+        "## Drift Check",
+        "## Claim Check",
+        "## Verdict"
+    )
+
+    foreach ($section in $requiredSections) {
+        if ($review -notmatch [regex]::Escape($section)) {
+            Add-Failure "External review is missing required section: $section"
+        }
+    }
+
+    if ($review -match "Pending\.") {
+        Add-Failure "External review still has the placeholder verdict."
+    }
+
+    return $true
+}
+
+function Test-AgentClaims([string]$ArtifactPath, [string[]]$ChangedFiles) {
+    if (-not (Test-Path $ArtifactPath)) {
+        return
+    }
+
+    $claims = Get-Content $ArtifactPath -Raw
+    $claimFileLines = $claims -split "`r?`n" |
+        Where-Object { $_ -match "^\s*-\s+(.+)$" } |
+        ForEach-Object { $Matches[1].Trim().Replace("\", "/") }
+
+    $repoPaths = $claimFileLines | Where-Object {
+        $_ -match "\.(md|ts|tsx|js|jsx|json|css|scss|py|go|rs|java|cs|yml|yaml|ps1|sh)$"
+    }
+
+    foreach ($path in $repoPaths) {
+        if ($ChangedFiles -notcontains $path -and -not (Test-Path $path)) {
+            Add-Failure "Agent claim references a file that is not changed and does not exist: $path"
+        }
+    }
+
+    foreach ($path in $ChangedFiles) {
+        if ($claims -match [regex]::Escape("no app changes") -and (Test-PathPrefix $path $config.sourcePathPrefixes)) {
+            Add-Failure "Agent claims no app changes, but source file changed: $path"
+        }
+    }
+
+    if ($claims -match "(?i)(build|test|lint).*(pass|passed|green)" -and $claims -notmatch "Evidence Files") {
+        Add-Failure "Agent claims passing checks without an Evidence Files section."
+    }
+}
+
+function Test-PropDrilling([string]$DiffText) {
+    if (-not $DiffText) {
+        return
+    }
+
+    $addedLines = $DiffText -split "`n" | Where-Object { $_ -match "^\+[^+]" }
+    $propPattern = "\b([A-Za-z_][A-Za-z0-9_]*)=\{"
+    $propCounts = @{}
+
+    foreach ($line in $addedLines) {
+        $matches = [regex]::Matches($line, $propPattern)
+        foreach ($match in $matches) {
+            $name = $match.Groups[1].Value
+            if (-not $propCounts.ContainsKey($name)) {
+                $propCounts[$name] = 0
+            }
+            $propCounts[$name]++
+        }
+
+        $componentProps = [regex]::Match($line, "function\s+[A-Z][A-Za-z0-9_]*\s*\(([^)]*)\)")
+        if ($componentProps.Success) {
+            $count = ([regex]::Matches($componentProps.Groups[1].Value, "\b[A-Za-z_][A-Za-z0-9_]*\b")).Count
+            if ($count -gt [int]$config.propDrilling.maxPropsOnComponent) {
+                $message = "Possible oversized component prop surface: $($componentProps.Value)"
+                if ($strictReview -and $config.propDrilling.failInStrictMode) {
+                    Add-Failure $message
+                } else {
+                    Add-Warning $message
+                }
+            }
+        }
+    }
+
+    foreach ($key in $propCounts.Keys) {
+        if ($propCounts[$key] -ge [int]$config.propDrilling.repeatedPropThreshold) {
+            $message = "Possible prop drilling: prop '$key' appears in $($propCounts[$key]) added JSX bindings."
+            if ($strictReview -and $config.propDrilling.failInStrictMode) {
+                Add-Failure $message
+            } else {
+                Add-Warning $message
+            }
+        }
+    }
+}
+
+$changedFiles = Get-ChangedFiles
+$diffText = Get-DiffText
+$branch = (& git branch --show-current).Trim()
+$strictReview = $Strict -or ($env:BLUEPRINT_REQUIRE_EXTERNAL_AI_REVIEW -eq "1")
+
+if ($changedFiles.Count -eq 0) {
+    Write-Host "Blueprint guardrails: no changed files for mode '$Mode'."
+    exit 0
+}
+
+if ($Mode -eq "pre-commit" -and $config.protectedBranches -contains $branch) {
+    Add-Failure "Refusing to commit directly on protected branch '$branch'. Use a feature or fix branch."
+}
+
+$sourceChanged = $false
+$workflowChanged = $false
+foreach ($file in $changedFiles) {
+    if (Test-PathPrefix $file $config.sourcePathPrefixes) {
+        $sourceChanged = $true
+    }
+    if (Test-PathPrefix $file $config.workflowPathPrefixes) {
+        $workflowChanged = $true
+    }
+}
+
+if ($sourceChanged -and (Test-Path "blueprint/context/current-feature.md")) {
+    $currentFeature = Get-Content "blueprint/context/current-feature.md" -Raw
+    if ($currentFeature -match "_Nothing in progress") {
+        Add-Failure "Source files changed while current-feature.md says nothing is in progress."
+    }
+}
+
+if ($sourceChanged -and (Test-Path "blueprint/context/project-overview.md")) {
+    $overview = Get-Content "blueprint/context/project-overview.md" -Raw
+    if ($overview -match "_Not generated yet") {
+        Add-Failure "Source files changed before project-overview.md was generated."
+    }
+}
+
+if ($workflowChanged) {
+    Add-Warning "Workflow files changed. Review adapter symmetry between .agents and .claude when applicable."
+}
+
+$reviewArtifact = Join-Path $repoRoot $config.externalReview.artifact
+if ($strictReview -and ($sourceChanged -or $workflowChanged -or $Mode -eq "ci")) {
+    if (-not (Test-ReviewArtifact $reviewArtifact)) {
+        Add-Failure "Strict mode requires an external review artifact at $($config.externalReview.artifact)."
+    }
+} elseif (($sourceChanged -or $workflowChanged) -and -not (Test-Path $reviewArtifact)) {
+    Add-Warning "No external diff review found at $($config.externalReview.artifact). Set BLUEPRINT_REQUIRE_EXTERNAL_AI_REVIEW=1 in CI to make this a hard gate."
+}
+
+$claimsArtifact = Join-Path $repoRoot $config.claimReport.artifact
+Test-AgentClaims $claimsArtifact $changedFiles
+Test-PropDrilling $diffText
+
+Write-Host "Blueprint guardrails checked $($changedFiles.Count) changed file(s) in mode '$Mode'."
+foreach ($warning in $warnings) {
+    Write-Warning $warning
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Blueprint guardrails failed:"
+    foreach ($failure in $failures) {
+        Write-Host " - $failure"
+    }
+    exit 1
+}
+
+Write-Host "Blueprint guardrails passed."

--- a/scripts/guardrails/Request-ExternalAiReview.ps1
+++ b/scripts/guardrails/Request-ExternalAiReview.ps1
@@ -1,0 +1,87 @@
+param(
+    [string]$BaseRef = "origin/main",
+    [string]$OutputPath = "blueprint/reviews/current-diff-review.md"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (& git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
+
+if (-not $env:BLUEPRINT_AI_REVIEW_CMD) {
+    throw "Set BLUEPRINT_AI_REVIEW_CMD to a command that accepts the prompt file path as its first argument and writes review markdown to stdout."
+}
+
+$mergeBase = (& git merge-base HEAD $BaseRef 2>$null)
+if (-not $mergeBase) {
+    $mergeBase = (& git rev-parse HEAD~1)
+}
+
+$changedFiles = (& git diff --name-only "$mergeBase...HEAD") -join "`n"
+$diff = (& git diff --find-renames "$mergeBase...HEAD") -join "`n"
+$overview = if (Test-Path "blueprint/context/project-overview.md") { Get-Content "blueprint/context/project-overview.md" -Raw } else { "" }
+$standards = if (Test-Path "blueprint/context/coding-standards.md") { Get-Content "blueprint/context/coding-standards.md" -Raw } else { "" }
+$feature = if (Test-Path "blueprint/context/current-feature.md") { Get-Content "blueprint/context/current-feature.md" -Raw } else { "" }
+
+$prompt = @"
+You are the independent reviewer for an AI-assisted coding workflow.
+
+Review the current diff for:
+- architecture drift from the project overview and coding standards
+- hallucinated or misleading implementation claims
+- scope creep beyond the current feature or fix
+- shortcuts that a single-session implementation agent might take
+- missing tests, missing verification, or unproven done-when claims
+- prop drilling, oversized component surfaces, or avoidable coupling
+
+Return markdown with exactly these sections:
+
+## Reviewer
+## Diff Scope
+## Findings
+## Drift Check
+## Claim Check
+## Verdict
+
+Use severity labels P0, P1, P2, P3 for findings. If the diff should not merge,
+say that clearly in Verdict.
+
+# Changed files
+
+$changedFiles
+
+# Project overview
+
+$overview
+
+# Coding standards
+
+$standards
+
+# Current feature
+
+$feature
+
+# Diff
+
+$diff
+"@
+
+$tempPrompt = New-TemporaryFile
+Set-Content -Path $tempPrompt -Value $prompt -Encoding UTF8
+
+$env:BLUEPRINT_REVIEW_PROMPT_FILE = [string]$tempPrompt
+$review = Invoke-Expression "$($env:BLUEPRINT_AI_REVIEW_CMD) `"$tempPrompt`""
+Remove-Item $tempPrompt -Force
+
+if (-not $review) {
+    throw "External AI review command produced no output."
+}
+
+$outFullPath = Join-Path $repoRoot $OutputPath
+$outDir = Split-Path $outFullPath -Parent
+if (-not (Test-Path $outDir)) {
+    New-Item -ItemType Directory -Path $outDir | Out-Null
+}
+
+Set-Content -Path $outFullPath -Value $review -Encoding UTF8
+Write-Host "Wrote external review to $OutputPath"

--- a/scripts/guardrails/hooks/pre-commit
+++ b/scripts/guardrails/hooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode pre-commit
+elif command -v powershell >/dev/null 2>&1; then
+  powershell -NoProfile -ExecutionPolicy Bypass -File scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode pre-commit
+else
+  echo "Blueprint guardrails require PowerShell. Install PowerShell or run scripts/guardrails/Invoke-BlueprintGuardrails.ps1 manually."
+  exit 1
+fi

--- a/scripts/guardrails/hooks/pre-push
+++ b/scripts/guardrails/hooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode pre-push
+elif command -v powershell >/dev/null 2>&1; then
+  powershell -NoProfile -ExecutionPolicy Bypass -File scripts/guardrails/Invoke-BlueprintGuardrails.ps1 -Mode pre-push
+else
+  echo "Blueprint guardrails require PowerShell. Install PowerShell or run scripts/guardrails/Invoke-BlueprintGuardrails.ps1 manually."
+  exit 1
+fi


### PR DESCRIPTION
 This PR adds a lightweight enforcement layer on top of the existing Blueprint workflow.

  The current Blueprint already gives agents a strong process: spec first, small reviewed diffs, one feature at a time, and documented
  completion. The gap is that most of those controls are instruction-based. A single agent session can still accidentally or
  conveniently skip verification, overstate what passed, drift from the architecture, or make workflow edits that are hard to notice
  until later.

  This change adds script and CI-backed guardrails that inspect the actual Git diff rather than trusting the chat transcript or an
  agent’s summary.

  ## What changed

  - Added a reusable guardrail runner:
      - scripts/guardrails/Invoke-BlueprintGuardrails.ps1

  - Added local hook installer and hook templates:
      - pre-commit
      - pre-push

  - Added strict PR CI:
      - .github/workflows/blueprint-guardrails.yml

  - Added a PR template focused on:
      - why the change is needed
      - intended scope
      - verification evidence
      - drift and shortcut checks

  - Added review artifacts:
      - blueprint/reviews/current-diff-review.md
      - blueprint/reviews/agent-claims.md

  - Updated README, AGENTS, interaction docs, and both Codex/Claude skills to explain the new guardrail flow.

  ## Why this is needed

  AI coding workflows need more than good instructions. Agents can follow the happy path most of the time, but the risky cases are
  exactly where mechanical checks help:

  - claiming tests or builds passed without evidence
  - touching source files without an active feature/fix spec
  - changing workflow files without noticing adapter drift
  - merging changes before an external review looked at the diff
  - drifting from project architecture over several small edits
  - introducing prop-drilling or coupling while still satisfying the immediate prompt

  This PR makes those risks visible earlier.

  ## Design approach

  The guardrails are intentionally diff-based.

  They check Git state first, then compare review artifacts and agent claims against reality. Markdown remains useful as context and
  evidence, but it is not blindly trusted.

  Local mode is developer-friendly: objective problems fail, heuristic signals warn.

  Strict CI is tougher: it requires a real external review artifact before a PR can pass.

  ## Expected impact

  This keeps the Blueprint portable while giving it a stronger safety net for real agentic development. It does not replace human
  review or the existing spec loop. It adds a mechanical layer that catches drift, misleading claims, and skipped verification before
  they reach main.