### PR TITLE
Add GitHub Copilot adapter support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,15 @@ exposed through tool-specific adapters:
 
 - Codex: `.agents/skills/<skill>/SKILL.md`
 - Claude Code: `.claude/skills/<skill>/SKILL.md`
+- GitHub Copilot: `AGENTS.md` plus `.agents/skills/<skill>/SKILL.md`
 
-Unused adapters can be removed. Codex-only projects can delete `CLAUDE.md` and
-`.claude/`. Claude Code-only projects can delete `.agents/`, but should keep
-`AGENTS.md` because `CLAUDE.md` imports it.
+Unused adapters can be removed. Codex and GitHub Copilot share `.agents/`.
+Codex-only or Copilot-only projects can delete `CLAUDE.md` and `.claude/`.
+Claude Code-only projects can delete `.agents/`, but should keep `AGENTS.md`
+because `CLAUDE.md` imports it.
 
 When changing shared workflow behavior, update the matching skill in both
-adapter folders so Codex and Claude Code stay aligned.
+adapter folders so Codex, Claude Code, and GitHub Copilot stay aligned.
 
 Core skills:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ published `create-ai-blueprint` package.
 
 ## Unreleased
 
+### Added
+
+- Added GitHub Copilot support through the shared `AGENTS.md` and `.agents/skills/`
+  adapter files.
+
+### Changed
+
+- Added `--all` as the default installer mode. Kept `--both` as a deprecated
+  alias for `--all`.
+
 ## [0.9.1] - 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ helping you write.
 | Small diffs | Implementation happens one reviewed step at a time, with proof each step works. |
 | File-backed state | Plans, current work, and history live in markdown files, so context clears are survivable. |
 | Findings gate | `/audit` findings live in a ledger with durable IDs; open or unreviewed P0/P1 findings block `/complete`. |
-| Tool adapters | Codex uses `.agents/skills`; Claude Code uses `.claude/skills`. |
+| Tool adapters | Codex and GitHub Copilot use `.agents/skills`; Claude Code uses `.claude/skills`. |
 | Optional visibility | Commit the workflow files for portability, or keep them local with `.gitignore`. |
 
 ## Contents
@@ -284,9 +284,12 @@ The optional global `blueprint` command is status-only. Continue to use
 | --- | --- | --- |
 | Codex | Native project skills in `.agents/skills/` | `$feature`, `$implement`, or plain language |
 | Claude Code | Native project skills in `.claude/skills/` | `/feature`, `/implement`, and other slash commands |
+| GitHub Copilot | `AGENTS.md` and shared skills in `.agents/skills/` | Ask Copilot to run the matching skill |
 | Other AGENTS.md-aware tools | Shared project instructions plus readable skill files | Ask the agent to follow the matching `SKILL.md` |
 
-Install one adapter or both. The workflow state under `blueprint/` stays
+The installer defaults to all three adapters. Use `--codex`, `--claude`, or
+`--copilot` to install one adapter. `--both` remains as a deprecated alias for
+`--all` and prints a warning. The workflow state under `blueprint/` stays
 tool-independent, so a project can move between supported agents without moving
 its plan or history back into chat.
 
@@ -845,7 +848,7 @@ local files.
 
 When editing shared workflow behavior, keep the matching files in `.agents/skills`
 and `.claude/skills` aligned. Tool-specific invocation text is fine, but the
-actual build loop should stay the same across both adapters.
+actual build loop should stay the same across each adapter.
 
 ## Support and contributing
 
@@ -886,12 +889,13 @@ project plan. The `/prototype` helper can create throwaway static mockups in
 ### Works in other tools
 
 The blueprint is not Claude-specific. `AGENTS.md` is the cross-tool entry point,
-`.agents/skills` exposes the workflow to Codex, and `.claude/skills` exposes it
-to Claude Code.
+`.agents/skills` exposes the workflow to Codex and GitHub Copilot, and
+`.claude/skills` exposes it to Claude Code.
 
-You do not have to keep both adapters. For Codex-only work, keep `AGENTS.md`,
+You do not have to keep all adapters. For Codex-only work, keep `AGENTS.md`,
 `.agents/`, and `blueprint/`. For Claude Code-only work, keep `AGENTS.md`,
-`CLAUDE.md`, `.claude/`, and `blueprint/`. Keep both adapters if you switch
+`CLAUDE.md`, `.claude/`, and `blueprint/`. For GitHub Copilot-only work, keep
+`AGENTS.md`, `.agents/`, and `blueprint/`. Keep all adapters if you switch
 between tools.
 
 Use the native invocation style for your tool:
@@ -903,6 +907,8 @@ Use the native invocation style for your tool:
 - Claude Code: `/onboard`, `/discovery`, `/doctor`, `/adopt`, `/overview`, `/brief`,
   `/feature`, `/debug`, `/fix`, `/tests`, `/ci`, `/implement`, `/check`, `/try`, `/audit`, `/rollback`,
   `/complete`, `/release`, `/prototype`, `/status`. Autopilot: `/autopilot`.
+- GitHub Copilot: ask Copilot to run the matching skill or follow the local
+  `.agents/skills/<skill>/SKILL.md` file.
 - Other tools: ask the agent to follow the matching `SKILL.md`.
 
 ```text

--- a/packages/create-ai-blueprint/README.md
+++ b/packages/create-ai-blueprint/README.md
@@ -51,8 +51,9 @@ a completed feature from its archived spec and exact git commit. Rollbacks keep
 the original feature archive and use the normal implement, check, and complete
 gates.
 
-If you install the Blueprint while Claude Code is already open in the project,
-restart Claude Code in that folder so the newly added project skills appear.
+If you install `--claude` or `--all` while Claude Code is already open in the
+project, restart Claude Code in that folder so the newly added project skills
+appear.
 
 ## Tool support
 
@@ -60,6 +61,7 @@ restart Claude Code in that folder so the newly added project skills appear.
 | --- | --- | --- |
 | Codex | `.agents/skills/` | `$feature`, `$implement`, or plain language |
 | Claude Code | `.claude/skills/` | `/feature`, `/implement`, and other slash commands |
+| GitHub Copilot | `AGENTS.md` and `.agents/skills/` | Ask Copilot to run the matching skill |
 | Other tools | `AGENTS.md` plus readable skill files | Ask the agent to follow the matching `SKILL.md` |
 
 ## Options
@@ -67,12 +69,19 @@ restart Claude Code in that folder so the newly added project skills appear.
 ```bash
 npx create-ai-blueprint@latest -- --codex
 npx create-ai-blueprint@latest -- --claude
+npx create-ai-blueprint@latest -- --copilot
+npx create-ai-blueprint@latest -- --all
 npx create-ai-blueprint@latest -- --both
 npx create-ai-blueprint@latest -- --force
 npx create-ai-blueprint@latest -- --target ./my-app
 ```
 
 The same flags work with `npm create ai-blueprint@latest -- ...`.
+
+The installer defaults to `--all`. `--both` remains as a deprecated alias for
+`--all` and prints a warning. GitHub Copilot uses `AGENTS.md` and the shared
+`.agents/skills/` files; the installer does not manage
+`.github/copilot-instructions.md`.
 
 Use `--force` to overwrite existing Blueprint files. Without `--force`, the
 installer asks before overwriting in an interactive terminal and exits in

--- a/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
+++ b/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
@@ -17,10 +17,13 @@ import type { AdapterMode, PreparedUpdate, UpdateResult } from "../lib/update.js
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(__dirname, "..", "..");
 const templateRoot = path.join(packageRoot, "template");
+const ADAPTER_PROMPT =
+  "Install which adapter?\n1: Codex\n2: Claude Code\n3: GitHub Copilot\n4: all (default): ";
 
 interface CliOptions {
   adapter: AdapterMode | null;
   command: "install" | "status" | "update";
+  deprecatedBoth: boolean;
   dryRun: boolean;
   force: boolean;
   help: boolean;
@@ -35,7 +38,7 @@ interface TemplateEntry {
   target: string;
 }
 
-const adapterChoices = new Set<AdapterMode>(["codex", "claude", "both"]);
+const adapterChoices = new Set<AdapterMode>(["all", "claude", "codex", "copilot"]);
 
 async function runCli(
   args: readonly string[] = process.argv.slice(2),
@@ -103,6 +106,10 @@ async function runCli(
     return;
   }
 
+  if (options.deprecatedBoth) {
+    console.warn("Warning: --both is deprecated; use --all instead.");
+  }
+
   const adapter = await resolveAdapter(options);
   const entries = getTemplateEntries(adapter);
   const existingEntries = entries.filter((entry) =>
@@ -135,6 +142,7 @@ function parseArgs(args: readonly string[]): CliOptions {
   const options: CliOptions = {
     adapter: null,
     command: "install",
+    deprecatedBoth: false,
     dryRun: false,
     force: false,
     help: false,
@@ -198,7 +206,13 @@ function parseArgs(args: readonly string[]): CliOptions {
       continue;
     }
 
-    if (arg === "--codex" || arg === "--claude" || arg === "--both") {
+    if (arg === "--both") {
+      options.deprecatedBoth = true;
+      modeFlags.push("all");
+      continue;
+    }
+
+    if (arg === "--all" || arg === "--claude" || arg === "--codex" || arg === "--copilot") {
       modeFlags.push(arg.slice(2) as AdapterMode);
       continue;
     }
@@ -222,14 +236,16 @@ function parseArgs(args: readonly string[]): CliOptions {
   }
 
   if (modeFlags.length > 1) {
-    throw new Error("Choose only one adapter option: --codex, --claude, or --both.");
+    throw new Error(
+      "Choose only one adapter option: --codex, --claude, --copilot, --all, or --both."
+    );
   }
 
   options.adapter = modeFlags[0] || null;
 
   if (options.command === "update" && options.adapter) {
     throw new Error(
-      "Update detects the installed adapters. Do not pass --codex, --claude, or --both."
+      "Update detects the installed adapters. Do not pass --codex, --claude, --copilot, --all, or --both."
     );
   }
 
@@ -255,7 +271,7 @@ async function resolveAdapter(options: CliOptions): Promise<AdapterMode> {
   }
 
   if (options.yes || !process.stdin.isTTY) {
-    return "both";
+    return "all";
   }
 
   const rl = readline.createInterface({
@@ -264,14 +280,12 @@ async function resolveAdapter(options: CliOptions): Promise<AdapterMode> {
   });
 
   try {
-    const answer = await rl.question(
-      "Install which adapters? [1] Codex, [2] Claude Code, [3] both (default): "
-    );
+    const answer = await rl.question(ADAPTER_PROMPT);
 
     const normalized = answer.trim().toLowerCase();
 
-    if (normalized === "" || normalized === "3" || normalized === "both") {
-      return "both";
+    if (normalized === "" || normalized === "4" || normalized === "all") {
+      return "all";
     }
 
     if (normalized === "1" || normalized === "codex") {
@@ -286,7 +300,11 @@ async function resolveAdapter(options: CliOptions): Promise<AdapterMode> {
       return "claude";
     }
 
-    throw new Error("Choose 1, 2, or 3.");
+    if (normalized === "3" || normalized === "copilot" || normalized === "github copilot") {
+      return "copilot";
+    }
+
+    throw new Error("Choose 1, 2, 3, or 4.");
   } finally {
     rl.close();
   }
@@ -302,11 +320,11 @@ function getTemplateEntries(adapter: AdapterMode): TemplateEntry[] {
     { source: "blueprint", target: "blueprint" }
   ];
 
-  if (adapter === "codex" || adapter === "both") {
+  if (adapter === "all" || adapter === "codex" || adapter === "copilot") {
     entries.push({ source: ".agents", target: ".agents" });
   }
 
-  if (adapter === "claude" || adapter === "both") {
+  if (adapter === "all" || adapter === "claude") {
     entries.push({ source: "CLAUDE.md", target: "CLAUDE.md" });
     entries.push({ source: ".claude", target: ".claude" });
   }
@@ -512,11 +530,15 @@ function getNextCommand(adapter: AdapterMode): string {
     return "/onboard";
   }
 
-  return "$onboard or /onboard";
+  if (adapter === "copilot") {
+    return "Ask Copilot to run the onboard skill.";
+  }
+
+  return "$onboard, /onboard, or ask Copilot to run the onboard skill.";
 }
 
 function printClaudeRestartNote(adapter: AdapterMode): void {
-  if (adapter === "codex") {
+  if (adapter !== "all" && adapter !== "claude") {
     return;
   }
 
@@ -634,12 +656,16 @@ Usage:
   npx create-ai-blueprint@latest status --json
   npx create-ai-blueprint@latest -- --codex
   npx create-ai-blueprint@latest -- --claude
+  npx create-ai-blueprint@latest -- --copilot
+  npx create-ai-blueprint@latest -- --all
   npx create-ai-blueprint@latest -- --both
 
 Options:
   --codex          Install AGENTS.md, .agents/, and blueprint/
   --claude         Install AGENTS.md, CLAUDE.md, .claude/, and blueprint/
-  --both           Install both Codex and Claude Code adapters
+  --copilot        Install AGENTS.md, .agents/, and blueprint/
+  --all            Install Codex, Claude Code, and GitHub Copilot adapters
+  --both           Deprecated alias for --all
   --target, -t     Target directory, defaults to the current directory
   --force, -f      Install: overwrite matching files. Update: back up and replace managed conflicts
   --yes, -y        Use defaults in non-interactive installs
@@ -701,6 +727,7 @@ if (
 }
 
 export {
+  ADAPTER_PROMPT,
   getGlobalCliInstallCommand,
   getTemplateEntries,
   isGlobalCliInstallConfirmed,

--- a/packages/create-ai-blueprint/lib/project-metadata.ts
+++ b/packages/create-ai-blueprint/lib/project-metadata.ts
@@ -3,9 +3,12 @@ import path from "node:path";
 
 import { findProjectRoot } from "./project-root.js";
 import { readManifest } from "./update.js";
+import type { Adapter } from "./update.js";
 
 const PROJECT_STATE_SCHEMA_VERSION = 1 as const;
-type ProjectAdapter = "codex" | "claude";
+type ProjectAdapter = Adapter;
+type LegacyFilesystemAdapter = Exclude<ProjectAdapter, "copilot">;
+const ADAPTER_ORDER: readonly ProjectAdapter[] = ["codex", "claude", "copilot"];
 
 interface ProjectWarning {
   code: "invalid_manifest";
@@ -25,7 +28,7 @@ interface ProjectMetadata {
   warnings: ProjectWarning[];
 }
 
-const ADAPTER_PATHS: Record<ProjectAdapter, string> = {
+const ADAPTER_PATHS: Record<LegacyFilesystemAdapter, string> = {
   codex: path.join(".agents", "skills"),
   claude: path.join(".claude", "skills")
 };
@@ -59,13 +62,20 @@ async function readProjectMetadata(
     },
     blueprint: {
       version: manifest?.version || null,
-      adapters: await detectAdapters(projectRoot)
+      adapters: await detectAdapters(projectRoot, manifest?.adapters)
     },
     warnings
   };
 }
 
-async function detectAdapters(projectRoot: string): Promise<ProjectAdapter[]> {
+async function detectAdapters(
+  projectRoot: string,
+  manifestAdapters?: readonly ProjectAdapter[]
+): Promise<ProjectAdapter[]> {
+  if (manifestAdapters) {
+    return ADAPTER_ORDER.filter((adapter) => manifestAdapters.includes(adapter));
+  }
+
   const adapters: ProjectAdapter[] = [];
 
   for (const adapter of ["codex", "claude"] as const) {

--- a/packages/create-ai-blueprint/lib/update.ts
+++ b/packages/create-ai-blueprint/lib/update.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 const CONTROL_DIR = "blueprint/.state";
 const MANIFEST_PATH = `${CONTROL_DIR}/manifest.json`;
 const MANIFEST_SCHEMA_VERSION = 1;
-type Adapter = "codex" | "claude";
-type AdapterMode = Adapter | "both";
+type Adapter = "codex" | "claude" | "copilot";
+type AdapterMode = Adapter | "all";
 
 interface TemplateFile {
   source: string;
@@ -89,12 +89,13 @@ interface InstallManifestOptions {
 const MANAGED_ROOTS: Record<Adapter | "common", readonly string[]> = {
   common: ["blueprint/README.md"],
   codex: [".agents/skills"],
-  claude: [".claude/skills"]
+  claude: [".claude/skills"],
+  copilot: [".agents/skills"]
 };
 
 function adapterListFromMode(adapter: AdapterMode): Adapter[] {
-  if (adapter === "both") {
-    return ["codex", "claude"];
+  if (adapter === "all") {
+    return ["codex", "claude", "copilot"];
   }
 
   return [adapter];
@@ -196,7 +197,7 @@ async function readManifest(targetDir: string): Promise<Manifest | null> {
 }
 
 function validateManifest(manifest: unknown): asserts manifest is Manifest {
-  const validAdapters: readonly Adapter[] = ["codex", "claude"];
+  const validAdapters: readonly Adapter[] = ["codex", "claude", "copilot"];
   const validManagedFiles =
     isRecord(manifest) &&
     isRecord(manifest.managedFiles) &&
@@ -499,7 +500,11 @@ async function detectInstalledAdapters(
   targetDir: string,
   manifest: Manifest | null
 ): Promise<Adapter[]> {
-  const adapters = new Set<Adapter>(manifest?.adapters || []);
+  if (manifest) {
+    return [...manifest.adapters];
+  }
+
+  const adapters = new Set<Adapter>();
 
   if (await pathExists(targetPath(targetDir, ".agents/skills"))) {
     adapters.add("codex");

--- a/packages/create-ai-blueprint/test/project-metadata.test.ts
+++ b/packages/create-ai-blueprint/test/project-metadata.test.ts
@@ -54,6 +54,27 @@ test("readProjectMetadata reports an invalid manifest without hiding project ide
   ]);
 });
 
+test("readProjectMetadata keeps Copilot distinct from Codex through the manifest", async (t) => {
+  const workspace = await createWorkspace(t);
+  const projectRoot = path.join(workspace, "app");
+
+  await fs.cp(fixtureRoot, projectRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(projectRoot, "blueprint", ".state", "manifest.json"),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      version: "0.9.1",
+      adapters: ["copilot"],
+      managedFiles: {}
+    }, null, 2)}\n`
+  );
+
+  const metadata = await readProjectMetadata(projectRoot);
+
+  assert.equal(metadata.blueprint.version, "0.9.1");
+  assert.deepEqual(metadata.blueprint.adapters, ["copilot"]);
+});
+
 test("readProjectMetadata rejects paths outside a Blueprint project", async (t) => {
   const workspace = await createWorkspace(t);
 

--- a/packages/create-ai-blueprint/test/status.test.ts
+++ b/packages/create-ai-blueprint/test/status.test.ts
@@ -32,6 +32,20 @@ test("readProjectStatus reports active work, findings, Git, and the next step", 
 `,
     branch: "feature/status-command"
   });
+
+  test("readProjectStatus reports Copilot from the manifest", async (t) => {
+    const projectRoot = await createProject(t, {
+      currentWork: resetCurrentWork(),
+      findings: emptyFindings(),
+      branch: "feature/copilot-status",
+      adapters: ["copilot"]
+    });
+
+    const status = await readProjectStatus(projectRoot);
+
+    assert.deepEqual(status.blueprint.adapters, ["copilot"]);
+    assert.match(formatHumanStatus(status), /Adapters\s+copilot/);
+  });
   await fs.appendFile(path.join(projectRoot, "src.ts"), "export const dirty = true;\n");
 
   const status = await readProjectStatus(projectRoot);
@@ -215,6 +229,7 @@ test("shouldUseColor requires a TTY and respects NO_COLOR", () => {
 });
 
 interface ProjectOptions {
+  adapters?: readonly ("claude" | "codex" | "copilot")[];
   currentWork: string;
   findings: string;
   branch: string;
@@ -256,7 +271,7 @@ async function createProject(
     `${JSON.stringify({
       schemaVersion: 1,
       version: "0.8.0",
-      adapters: ["codex", "claude"],
+      adapters: options.adapters || ["codex", "claude"],
       managedFiles: {}
     }, null, 2)}\n`
   );

--- a/packages/create-ai-blueprint/test/status.test.ts
+++ b/packages/create-ai-blueprint/test/status.test.ts
@@ -33,19 +33,6 @@ test("readProjectStatus reports active work, findings, Git, and the next step", 
     branch: "feature/status-command"
   });
 
-  test("readProjectStatus reports Copilot from the manifest", async (t) => {
-    const projectRoot = await createProject(t, {
-      currentWork: resetCurrentWork(),
-      findings: emptyFindings(),
-      branch: "feature/copilot-status",
-      adapters: ["copilot"]
-    });
-
-    const status = await readProjectStatus(projectRoot);
-
-    assert.deepEqual(status.blueprint.adapters, ["copilot"]);
-    assert.match(formatHumanStatus(status), /Adapters\s+copilot/);
-  });
   await fs.appendFile(path.join(projectRoot, "src.ts"), "export const dirty = true;\n");
 
   const status = await readProjectStatus(projectRoot);
@@ -81,6 +68,20 @@ test("readProjectStatus reports active work, findings, Git, and the next step", 
   });
   assert.equal(status.completion.state, "blocked");
   assert.deepEqual(status.warnings, []);
+});
+
+test("readProjectStatus reports Copilot from the manifest", async (t) => {
+  const projectRoot = await createProject(t, {
+    currentWork: resetCurrentWork(),
+    findings: emptyFindings(),
+    branch: "feature/copilot-status",
+    adapters: ["copilot"]
+  });
+
+  const status = await readProjectStatus(projectRoot);
+
+  assert.deepEqual(status.blueprint.adapters, ["copilot"]);
+  assert.match(formatHumanStatus(status), /Adapters\s+copilot/);
 });
 
 test("readProjectStatus selects overview before new feature work", async (t) => {

--- a/packages/create-ai-blueprint/test/update.test.ts
+++ b/packages/create-ai-blueprint/test/update.test.ts
@@ -5,18 +5,33 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 
 import {
+  ADAPTER_PROMPT,
+  getTemplateEntries,
   getGlobalCliInstallCommand,
   isGlobalCliInstallConfirmed,
   parseArgs,
   shouldOfferGlobalCliInstall
 } from "../bin/create-ai-blueprint.js";
-import { CONTROL_DIR, MANIFEST_PATH, applyPreparedUpdate, prepareUpdate, readManifest, writeInstallManifest } from "../lib/update.js";
+import {
+  CONTROL_DIR,
+  MANIFEST_PATH,
+  adapterListFromMode,
+  applyPreparedUpdate,
+  prepareUpdate,
+  readManifest,
+  writeInstallManifest
+} from "../lib/update.js";
 
 test("parseArgs supports install and update modes", () => {
+  assert.equal(
+    ADAPTER_PROMPT,
+    "Install which adapter?\n1: Codex\n2: Claude Code\n3: GitHub Copilot\n4: all (default): "
+  );
   assert.equal(parseArgs([]).command, "install");
   assert.deepEqual(parseArgs(["update", "--dry-run"]), {
     adapter: null,
     command: "update",
+    deprecatedBoth: false,
     dryRun: true,
     force: false,
     help: false,
@@ -28,6 +43,7 @@ test("parseArgs supports install and update modes", () => {
   assert.deepEqual(parseArgs(["status", "--json", "--target", "./app"]), {
     adapter: null,
     command: "status",
+    deprecatedBoth: false,
     dryRun: false,
     force: false,
     help: false,
@@ -48,6 +64,32 @@ test("parseArgs supports install and update modes", () => {
     () => parseArgs(["--json"]),
     /--json is available only with the status command/
   );
+  assert.equal(parseArgs(["--copilot"]).adapter, "copilot");
+  assert.equal(parseArgs(["--all"]).adapter, "all");
+  assert.deepEqual(parseArgs(["--both"]), {
+    adapter: "all",
+    command: "install",
+    deprecatedBoth: true,
+    dryRun: false,
+    force: false,
+    help: false,
+    json: false,
+    target: null,
+    version: false,
+    yes: false
+  });
+});
+
+test("Copilot shares the .agents adapter files without managing Copilot instructions", () => {
+  assert.deepEqual(
+    getTemplateEntries("copilot").map((entry) => entry.target),
+    ["AGENTS.md", "blueprint", ".agents"]
+  );
+  assert.deepEqual(
+    getTemplateEntries("all").map((entry) => entry.target),
+    ["AGENTS.md", "blueprint", ".agents", "CLAUDE.md", ".claude"]
+  );
+  assert.deepEqual(adapterListFromMode("all"), ["codex", "claude", "copilot"]);
 });
 
 test("global CLI installation is offered only after an interactive install", () => {
@@ -111,6 +153,76 @@ test("new installs record only Blueprint-owned managed files", async (t) => {
     await fs.readFile(path.join(targetDir, "blueprint/build-plan.md"), "utf8"),
     "Project roadmap\n"
   );
+});
+
+test("Copilot manifests remain distinct from Codex when they share skills", async (t) => {
+  const workspace = await createWorkspace(t);
+  const templateRoot = path.join(workspace, "template");
+  const targetDir = path.join(workspace, "target");
+  const files = {
+    "blueprint/README.md": "Blueprint docs\n",
+    ".agents/skills/check/SKILL.md": "Check skill\n"
+  };
+
+  await writeFiles(templateRoot, files);
+  await writeFiles(targetDir, files);
+  const manifest = await writeInstallManifest({
+    targetDir,
+    templateRoot,
+    version: "1.0.0",
+    adapter: "copilot"
+  });
+
+  assert.deepEqual(manifest.adapters, ["copilot"]);
+  assert.deepEqual(Object.keys(manifest.managedFiles), [
+    ".agents/skills/check/SKILL.md",
+    "blueprint/README.md"
+  ]);
+
+  const prepared = await prepareUpdate({
+    targetDir,
+    templateRoot,
+    version: "1.1.0"
+  });
+
+  assert.deepEqual(prepared.adapters, ["copilot"]);
+});
+
+test("updates preserve pre-Copilot Codex and Claude manifests", async (t) => {
+  const workspace = await createWorkspace(t);
+  const templateRoot = path.join(workspace, "template");
+  const targetDir = path.join(workspace, "target");
+  const files = {
+    "blueprint/README.md": "Blueprint docs\n",
+    ".agents/skills/check/SKILL.md": "Check skill\n",
+    ".claude/skills/check/SKILL.md": "Check skill\n"
+  };
+
+  await writeFiles(templateRoot, files);
+  await writeFiles(targetDir, files);
+  const allManifest = await writeInstallManifest({
+    targetDir,
+    templateRoot,
+    version: "1.0.0",
+    adapter: "all"
+  });
+  await fs.writeFile(
+    path.join(targetDir, MANIFEST_PATH),
+    `${JSON.stringify({ ...allManifest, adapters: ["claude", "codex"] }, null, 2)}\n`
+  );
+
+  const prepared = await prepareUpdate({
+    targetDir,
+    templateRoot,
+    version: "1.1.0"
+  });
+
+  assert.deepEqual(prepared.adapters, ["claude", "codex"]);
+  assert.deepEqual(prepared.desiredManifest.adapters, ["claude", "codex"]);
+
+  await applyPreparedUpdate(prepared);
+
+  assert.deepEqual((await readManifest(targetDir))?.adapters, ["claude", "codex"]);
 });
 
 test("update replaces unchanged managed files and preserves project files", async (t) => {

--- a/scripts/e2e/harness.ts
+++ b/scripts/e2e/harness.ts
@@ -249,8 +249,8 @@ function getAgentName(): AgentName {
   throw new Error(`Unsupported E2E_AGENT: ${configured}. Use "claude" or "copilot".`);
 }
 
-function getDefaultAdapterFlag(): "--both" | "--claude" {
-  return getAgentName() === "copilot" ? "--both" : "--claude";
+function getDefaultAdapterFlag(): "--all" | "--claude" {
+  return getAgentName() === "copilot" ? "--all" : "--claude";
 }
 
 function ensureAgentAvailable(): void {

--- a/scripts/smoke-package.ts
+++ b/scripts/smoke-package.ts
@@ -9,7 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const packageRoot = path.join(repoRoot, "packages", "create-ai-blueprint");
 
-type Adapter = "codex" | "claude";
+type Adapter = "codex" | "claude" | "copilot";
 
 interface PackageManifest {
   schemaVersion: number;
@@ -19,9 +19,12 @@ interface PackageManifest {
 }
 
 const modes: Record<string, Adapter[]> = {
+  default: ["codex", "claude", "copilot"],
   codex: ["codex"],
   claude: ["claude"],
-  both: ["claude", "codex"]
+  copilot: ["copilot"],
+  all: ["codex", "claude", "copilot"],
+  both: ["codex", "claude", "copilot"]
 };
 
 function getErrorCode(error: unknown): string | undefined {
@@ -47,7 +50,10 @@ function parseManifest(content: string): PackageManifest {
     typeof manifest.schemaVersion !== "number" ||
     typeof manifest.version !== "string" ||
     !Array.isArray(manifest.adapters) ||
-    !manifest.adapters.every((adapter): adapter is Adapter => adapter === "codex" || adapter === "claude") ||
+    !manifest.adapters.every(
+      (adapter): adapter is Adapter =>
+        adapter === "codex" || adapter === "claude" || adapter === "copilot"
+    ) ||
     typeof manifest.managedFiles !== "object" ||
     manifest.managedFiles === null ||
     Array.isArray(manifest.managedFiles)
@@ -195,13 +201,50 @@ async function main(): Promise<void> {
       await fs.mkdir(targetDir, { recursive: true });
       const installResult = run(
         process.execPath,
-        [binary, "--target", targetDir, `--${mode}`, "--yes"],
+        [
+          binary,
+          "--target",
+          targetDir,
+          ...(mode === "default" ? [] : [`--${mode}`]),
+          "--yes"
+        ],
         workspace,
         true
       );
 
       if (!installResult.stdout.includes("Optional global CLI:")) {
         throw new Error(`${mode} install did not print the optional CLI command`);
+      }
+
+      if (
+        mode === "both" &&
+        !installResult.stderr.includes("Warning: --both is deprecated; use --all instead.")
+      ) {
+        throw new Error("both install did not print the deprecation warning");
+      }
+
+      if (
+        mode === "copilot" &&
+        (!installResult.stdout.includes("Ask Copilot to run the onboard skill.") ||
+          installResult.stdout.includes("Claude Code:"))
+      ) {
+        throw new Error("copilot install did not print Copilot-specific guidance");
+      }
+
+      if (
+        (mode === "all" || mode === "both" || mode === "default") &&
+        !installResult.stdout.includes(
+          "$onboard, /onboard, or ask Copilot to run the onboard skill."
+        )
+      ) {
+        throw new Error(`${mode} install did not print all-adapter guidance`);
+      }
+
+      if (
+        (mode === "all" || mode === "both" || mode === "default") &&
+        !installResult.stdout.includes("Claude Code: if this project was already open")
+      ) {
+        throw new Error(`${mode} install did not print Claude restart guidance`);
       }
 
       await validateInstall(targetDir, metadata.version, adapters);
@@ -239,9 +282,15 @@ async function main(): Promise<void> {
         true
       );
       const status = parseRecord(jsonStatusResult.stdout, `${mode} JSON status`);
+      const blueprint = status.blueprint;
 
       if (
         status.schemaVersion !== 1 ||
+        typeof blueprint !== "object" ||
+        blueprint === null ||
+        !Array.isArray((blueprint as { adapters?: unknown }).adapters) ||
+        JSON.stringify((blueprint as { adapters: unknown[] }).adapters) !==
+          JSON.stringify(adapters) ||
         !Array.isArray(status.warnings) ||
         !status.warnings.some(
           (warning) =>
@@ -309,7 +358,9 @@ async function main(): Promise<void> {
       await fs.rm(emptyTarget, { recursive: true, force: true });
     }
 
-    console.log("Packed installer passed for codex, claude, and both adapter modes.");
+    console.log(
+      "Packed installer passed for the default, Codex, Claude Code, GitHub Copilot, all, and both adapter modes."
+    );
   } finally {
     await fs.rm(workspace, { recursive: true, force: true });
   }
@@ -322,6 +373,8 @@ async function validateInstall(
 ): Promise<void> {
   const expectsCodex = adapters.includes("codex");
   const expectsClaude = adapters.includes("claude");
+  const expectsCopilot = adapters.includes("copilot");
+  const expectsSharedSkills = expectsCodex || expectsCopilot;
   const expectedPaths = [
     "AGENTS.md",
     "blueprint/README.md",
@@ -332,7 +385,7 @@ async function validateInstall(
     "blueprint/.state/.gitignore"
   ];
 
-  if (expectsCodex) {
+  if (expectsSharedSkills) {
     expectedPaths.push(
       ".agents/skills/discovery/SKILL.md",
       ".agents/skills/onboard/SKILL.md",
@@ -356,7 +409,7 @@ async function validateInstall(
   await requireMissing(path.join(targetDir, "README.md"));
   await requireMissing(path.join(targetDir, ".ai-blueprint"));
 
-  if (!expectsCodex) {
+  if (!expectsSharedSkills) {
     await requireMissing(path.join(targetDir, ".agents"));
   }
 
@@ -380,7 +433,10 @@ async function validateInstall(
     throw new Error(`Installed version mismatch: ${manifest.version} !== ${version}`);
   }
 
-  if (JSON.stringify(manifest.adapters) !== JSON.stringify(adapters)) {
+  if (
+    JSON.stringify([...manifest.adapters].sort()) !==
+    JSON.stringify([...adapters].sort())
+  ) {
     throw new Error(
       `Installed adapters mismatch: ${manifest.adapters.join(", ")} !== ${adapters.join(", ")}`
     );
@@ -388,7 +444,7 @@ async function validateInstall(
 
   const expectedManagedFiles = ["blueprint/README.md"];
 
-  if (expectsCodex) {
+  if (expectsSharedSkills) {
     expectedManagedFiles.push(
       ...(await listFiles(path.join(targetDir, ".agents", "skills"))).map(
         (file) => `.agents/skills/${file}`


### PR DESCRIPTION
## Summary

- Add GitHub Copilot support through `AGENTS.md` and shared `.agents/skills/` files.
- Add `--copilot` for Copilot-only installs.
- Make `--all` the default combined install mode.
- Keep `--both` as a deprecated alias for `--all` with a warning.
- Use the approved four-option interactive adapter prompt.
- Preserve manifest-backed adapter identity through installation, updates, project metadata, and status output.

## Scope

Rebased on `v0.9.1` and narrowed to the Copilot adapter work.

This change does not include universal adapter support, workflow safeguard changes, SHA policy changes, managed `.github/copilot-instructions.md`, or the Windows package-shim repair.

## Validation

- `npm run typecheck`
- `npm --prefix packages/create-ai-blueprint test`
- `npm run check:static`
- `npm run test:routing`
- Direct packed-package verification for default, `--codex`, `--claude`, `--copilot`, `--all`, and `--both`

`npm run test:package` remains blocked on Windows by an identical upstream `v0.9.1` `.cmd` shim quoting failure that occurs before adapter-mode tests run.