### PR TITLE
feat: add OpenCode adapter support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # AGENTS.md
 
 Instructions for AI coding agents working in this project. This is the cross-tool
-entry point: Codex, Cursor, GitHub Copilot, Gemini CLI, Aider, Zed, Windsurf, and
-others read `AGENTS.md`. Claude Code reads `CLAUDE.md`, which imports this file, so
-there is a single source of truth.
+entry point: Codex, Cursor, GitHub Copilot, OpenCode, Gemini CLI, Aider, Zed,
+Windsurf, and others read `AGENTS.md`. Claude Code reads `CLAUDE.md`, which
+imports this file, so there is a single source of truth.
 
 ## What this is
 
@@ -34,14 +34,16 @@ exposed through tool-specific adapters:
 - Codex: `.agents/skills/<skill>/SKILL.md`
 - Claude Code: `.claude/skills/<skill>/SKILL.md`
 - GitHub Copilot: `AGENTS.md` plus `.agents/skills/<skill>/SKILL.md`
+- OpenCode: `AGENTS.md` plus `.opencode/skills/<skill>/SKILL.md`
 
-Unused adapters can be removed. Codex and GitHub Copilot share `.agents/`.
-Codex-only or Copilot-only projects can delete `CLAUDE.md` and `.claude/`.
-Claude Code-only projects can delete `.agents/`, but should keep `AGENTS.md`
-because `CLAUDE.md` imports it.
+Unused adapters can be removed. Codex and GitHub Copilot share `.agents/`;
+OpenCode gets its own `.opencode/`, though it also reads `.agents/skills` and
+`.claude/skills` natively. Codex-only or Copilot-only projects can delete
+`CLAUDE.md` and `.claude/`. Claude Code-only projects can delete `.agents/`, but
+should keep `AGENTS.md` because `CLAUDE.md` imports it.
 
 When changing shared workflow behavior, update the matching skill in both
-adapter folders so Codex, Claude Code, and GitHub Copilot stay aligned.
+adapter folders so Codex, Claude Code, GitHub Copilot, and OpenCode stay aligned.
 
 Core skills:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ published `create-ai-blueprint` package.
 
 ## Unreleased
 
+### Added
+
+- Added OpenCode as an explicit adapter. `--opencode` installs `AGENTS.md`,
+  `.opencode/`, and `blueprint/`, and `--all` now covers Codex, Claude Code,
+  GitHub Copilot, and OpenCode. The `.opencode/skills/` tree is mirrored from
+  the shared skills at pack time, so there is no third hand-edited copy to keep
+  in sync.
+
 ## [0.12.1] - 2026-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ helping you write.
 | Small diffs | Implementation happens one reviewed step at a time, with proof each step works. |
 | File-backed state | Plans, current work, and history live in markdown files, so context clears are survivable. |
 | Findings gate | `/audit` findings live in a ledger with durable IDs; open or unreviewed P0/P1 findings block `/complete`. |
-| Tool adapters | Codex and GitHub Copilot use `.agents/skills`; Claude Code uses `.claude/skills`. |
+| Tool adapters | Codex and GitHub Copilot use `.agents/skills`; Claude Code uses `.claude/skills`; OpenCode uses `.opencode/skills`. |
 | Optional visibility | Commit the workflow files for portability, or keep them local with `.gitignore`. |
 
 ## Contents
@@ -310,12 +310,13 @@ updates.
 | Codex | Native project skills in `.agents/skills/` | `$feature`, `$implement`, or plain language |
 | Claude Code | Native project skills in `.claude/skills/` | `/feature`, `/implement`, and other slash commands |
 | GitHub Copilot | `AGENTS.md` and shared skills in `.agents/skills/` | Ask Copilot to run the matching skill |
+| OpenCode | `AGENTS.md` and native skills in `.opencode/skills/` | Ask OpenCode to run the matching skill |
 | Other AGENTS.md-aware tools | Shared project instructions plus readable skill files | Ask the agent to follow the matching `SKILL.md` |
 
-The installer defaults to all three adapters. Use `--codex`, `--claude`, or
-`--copilot` to install one adapter. `--both` remains as a deprecated alias for
-`--all` and prints a warning. The workflow state under `blueprint/` stays
-tool-independent, so a project can move between supported agents without moving
+The installer defaults to all four adapters. Use `--codex`, `--claude`,
+`--copilot`, or `--opencode` to install one adapter. `--both` remains as a
+deprecated alias for `--all` and prints a warning. The workflow state under
+`blueprint/` stays tool-independent, so a project can move between supported agents without moving
 its plan or history back into chat.
 
 ## The AI workflow
@@ -913,13 +914,15 @@ project plan. The `/prototype` helper can create throwaway static mockups in
 ### Works in other tools
 
 The blueprint is not Claude-specific. `AGENTS.md` is the cross-tool entry point,
-`.agents/skills` exposes the workflow to Codex and GitHub Copilot, and
-`.claude/skills` exposes it to Claude Code.
+`.agents/skills` exposes the workflow to Codex and GitHub Copilot,
+`.claude/skills` exposes it to Claude Code, and `.opencode/skills` exposes it to
+OpenCode.
 
 You do not have to keep all adapters. For Codex-only work, keep `AGENTS.md`,
 `.agents/`, and `blueprint/`. For Claude Code-only work, keep `AGENTS.md`,
 `CLAUDE.md`, `.claude/`, and `blueprint/`. For GitHub Copilot-only work, keep
-`AGENTS.md`, `.agents/`, and `blueprint/`. Keep all adapters if you switch
+`AGENTS.md`, `.agents/`, and `blueprint/`. For OpenCode-only work, keep
+`AGENTS.md`, `.opencode/`, and `blueprint/`. Keep all adapters if you switch
 between tools.
 
 Use the native invocation style for your tool:
@@ -933,6 +936,8 @@ Use the native invocation style for your tool:
   `/complete`, `/release`, `/prototype`, `/status`. Autopilot: `/autopilot`.
 - GitHub Copilot: ask Copilot to run the matching skill or follow the local
   `.agents/skills/<skill>/SKILL.md` file.
+- OpenCode: ask OpenCode to run the matching skill; it discovers them from
+  `.opencode/skills/`.
 - Other tools: ask the agent to follow the matching `SKILL.md`.
 
 ```text

--- a/packages/create-ai-blueprint/README.md
+++ b/packages/create-ai-blueprint/README.md
@@ -61,6 +61,7 @@ appear.
 | Codex | `.agents/skills/` | `$feature`, `$implement`, or plain language |
 | Claude Code | `.claude/skills/` | `/feature`, `/implement`, and other slash commands |
 | GitHub Copilot | `AGENTS.md` and `.agents/skills/` | Ask Copilot to run the matching skill |
+| OpenCode | `AGENTS.md` and `.opencode/skills/` | Ask OpenCode to run the matching skill |
 | Other tools | `AGENTS.md` plus readable skill files | Ask the agent to follow the matching `SKILL.md` |
 
 ## Options
@@ -69,6 +70,7 @@ appear.
 npx create-ai-blueprint@latest -- --codex
 npx create-ai-blueprint@latest -- --claude
 npx create-ai-blueprint@latest -- --copilot
+npx create-ai-blueprint@latest -- --opencode
 npx create-ai-blueprint@latest -- --all
 npx create-ai-blueprint@latest -- --both
 npx create-ai-blueprint@latest -- --force
@@ -80,7 +82,9 @@ The same flags work with `npm create ai-blueprint@latest -- ...`.
 The installer defaults to `--all`. `--both` remains as a deprecated alias for
 `--all` and prints a warning. GitHub Copilot uses `AGENTS.md` and the shared
 `.agents/skills/` files; the installer does not manage
-`.github/copilot-instructions.md`.
+`.github/copilot-instructions.md`. OpenCode gets its own `.opencode/skills/`
+tree, mirrored from the shared skills; it also reads `.agents/skills/` and
+`.claude/skills/` natively, so those adapters work in OpenCode too.
 
 Use `--force` to overwrite existing Blueprint files. Without `--force`, the
 installer asks before overwriting in an interactive terminal and exits in

--- a/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
+++ b/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
@@ -19,7 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(__dirname, "..", "..");
 const templateRoot = path.join(packageRoot, "template");
 const ADAPTER_PROMPT =
-  "Install which adapter?\n1: Codex\n2: Claude Code\n3: GitHub Copilot\n4: all (default): ";
+  "Install which adapter?\n1: Codex\n2: Claude Code\n3: GitHub Copilot\n4: OpenCode\n5: all (default): ";
 
 interface CliOptions {
   adapter: AdapterMode | null;
@@ -43,7 +43,7 @@ interface TemplateEntry {
 
 type GlobalCliAction = "install" | "update" | null;
 
-const adapterChoices = new Set<AdapterMode>(["all", "claude", "codex", "copilot"]);
+const adapterChoices = new Set<AdapterMode>(["all", "claude", "codex", "copilot", "opencode"]);
 
 async function runCli(
   args: readonly string[] = process.argv.slice(2),
@@ -259,7 +259,13 @@ function parseArgs(args: readonly string[]): CliOptions {
       continue;
     }
 
-    if (arg === "--all" || arg === "--claude" || arg === "--codex" || arg === "--copilot") {
+    if (
+      arg === "--all" ||
+      arg === "--claude" ||
+      arg === "--codex" ||
+      arg === "--copilot" ||
+      arg === "--opencode"
+    ) {
       modeFlags.push(arg.slice(2) as AdapterMode);
       continue;
     }
@@ -284,7 +290,7 @@ function parseArgs(args: readonly string[]): CliOptions {
 
   if (modeFlags.length > 1) {
     throw new Error(
-      "Choose only one adapter option: --codex, --claude, --copilot, --all, or --both."
+      "Choose only one adapter option: --codex, --claude, --copilot, --opencode, --all, or --both."
     );
   }
 
@@ -292,7 +298,7 @@ function parseArgs(args: readonly string[]): CliOptions {
 
   if (options.command === "update" && options.adapter) {
     throw new Error(
-      "Update detects the installed adapters. Do not pass --codex, --claude, --copilot, --all, or --both."
+      "Update detects the installed adapters. Do not pass --codex, --claude, --copilot, --opencode, --all, or --both."
     );
   }
 
@@ -344,7 +350,7 @@ async function resolveAdapter(options: CliOptions): Promise<AdapterMode> {
 
     const normalized = answer.trim().toLowerCase();
 
-    if (normalized === "" || normalized === "4" || normalized === "all") {
+    if (normalized === "" || normalized === "5" || normalized === "all") {
       return "all";
     }
 
@@ -364,7 +370,11 @@ async function resolveAdapter(options: CliOptions): Promise<AdapterMode> {
       return "copilot";
     }
 
-    throw new Error("Choose 1, 2, 3, or 4.");
+    if (normalized === "4" || normalized === "opencode" || normalized === "open code") {
+      return "opencode";
+    }
+
+    throw new Error("Choose 1, 2, 3, 4, or 5.");
   } finally {
     rl.close();
   }
@@ -387,6 +397,10 @@ function getTemplateEntries(adapter: AdapterMode): TemplateEntry[] {
   if (adapter === "all" || adapter === "claude") {
     entries.push({ source: "CLAUDE.md", target: "CLAUDE.md" });
     entries.push({ source: ".claude", target: ".claude" });
+  }
+
+  if (adapter === "all" || adapter === "opencode") {
+    entries.push({ source: ".opencode", target: ".opencode" });
   }
 
   return entries;
@@ -596,7 +610,11 @@ function getNextCommand(adapter: AdapterMode): string {
     return "Ask Copilot to run the onboard skill.";
   }
 
-  return "$onboard, /onboard, or ask Copilot to run the onboard skill.";
+  if (adapter === "opencode") {
+    return "Ask OpenCode to run the onboard skill.";
+  }
+
+  return "$onboard, /onboard, or ask Copilot or OpenCode to run the onboard skill.";
 }
 
 function printClaudeRestartNote(adapter: AdapterMode): void {
@@ -828,6 +846,7 @@ Usage:
   npx create-ai-blueprint@latest -- --codex
   npx create-ai-blueprint@latest -- --claude
   npx create-ai-blueprint@latest -- --copilot
+  npx create-ai-blueprint@latest -- --opencode
   npx create-ai-blueprint@latest -- --all
   npx create-ai-blueprint@latest -- --both
 
@@ -835,7 +854,8 @@ Options:
   --codex          Install AGENTS.md, .agents/, and blueprint/
   --claude         Install AGENTS.md, CLAUDE.md, .claude/, and blueprint/
   --copilot        Install AGENTS.md, .agents/, and blueprint/
-  --all            Install Codex, Claude Code, and GitHub Copilot adapters
+  --opencode       Install AGENTS.md, .opencode/, and blueprint/
+  --all            Install Codex, Claude Code, GitHub Copilot, and OpenCode adapters
   --both           Deprecated alias for --all
   --target, -t     Target directory, defaults to the current directory
   --force, -f      Install: overwrite matching files. Update: back up and replace managed conflicts

--- a/packages/create-ai-blueprint/lib/project-metadata.ts
+++ b/packages/create-ai-blueprint/lib/project-metadata.ts
@@ -8,7 +8,7 @@ import type { Adapter } from "./update.js";
 const PROJECT_STATE_SCHEMA_VERSION = 1 as const;
 type ProjectAdapter = Adapter;
 type LegacyFilesystemAdapter = Exclude<ProjectAdapter, "copilot">;
-const ADAPTER_ORDER: readonly ProjectAdapter[] = ["codex", "claude", "copilot"];
+const ADAPTER_ORDER: readonly ProjectAdapter[] = ["codex", "claude", "copilot", "opencode"];
 
 interface ProjectWarning {
   code: "invalid_manifest";
@@ -30,7 +30,8 @@ interface ProjectMetadata {
 
 const ADAPTER_PATHS: Record<LegacyFilesystemAdapter, string> = {
   codex: path.join(".agents", "skills"),
-  claude: path.join(".claude", "skills")
+  claude: path.join(".claude", "skills"),
+  opencode: path.join(".opencode", "skills")
 };
 
 async function readProjectMetadata(
@@ -78,7 +79,7 @@ async function detectAdapters(
 
   const adapters: ProjectAdapter[] = [];
 
-  for (const adapter of ["codex", "claude"] as const) {
+  for (const adapter of ["codex", "claude", "opencode"] as const) {
     if (await isDirectory(path.join(projectRoot, ADAPTER_PATHS[adapter]))) {
       adapters.push(adapter);
     }

--- a/packages/create-ai-blueprint/lib/update.ts
+++ b/packages/create-ai-blueprint/lib/update.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 const CONTROL_DIR = "blueprint/.state";
 const MANIFEST_PATH = `${CONTROL_DIR}/manifest.json`;
 const MANIFEST_SCHEMA_VERSION = 1;
-type Adapter = "codex" | "claude" | "copilot";
+type Adapter = "codex" | "claude" | "copilot" | "opencode";
 type AdapterMode = Adapter | "all";
 
 interface TemplateFile {
@@ -90,13 +90,14 @@ const MANAGED_ROOTS: Record<Adapter | "common", readonly string[]> = {
   common: [],
   codex: [".agents/skills"],
   claude: [".claude/skills"],
-  copilot: [".agents/skills"]
+  copilot: [".agents/skills"],
+  opencode: [".opencode/skills"]
 };
 const RETIRED_MANAGED_PATHS = new Set(["blueprint/README.md"]);
 
 function adapterListFromMode(adapter: AdapterMode): Adapter[] {
   if (adapter === "all") {
-    return ["codex", "claude", "copilot"];
+    return ["codex", "claude", "copilot", "opencode"];
   }
 
   return [adapter];
@@ -198,7 +199,7 @@ async function readManifest(targetDir: string): Promise<Manifest | null> {
 }
 
 function validateManifest(manifest: unknown): asserts manifest is Manifest {
-  const validAdapters: readonly Adapter[] = ["codex", "claude", "copilot"];
+  const validAdapters: readonly Adapter[] = ["codex", "claude", "copilot", "opencode"];
   const validManagedFiles =
     isRecord(manifest) &&
     isRecord(manifest.managedFiles) &&
@@ -519,7 +520,11 @@ async function detectInstalledAdapters(
     adapters.add("claude");
   }
 
-  return (["codex", "claude"] as const).filter((adapter) => adapters.has(adapter));
+  if (await pathExists(targetPath(targetDir, ".opencode/skills"))) {
+    adapters.add("opencode");
+  }
+
+  return (["codex", "claude", "opencode"] as const).filter((adapter) => adapters.has(adapter));
 }
 
 async function writeManifest(targetDir: string, manifest: Manifest): Promise<void> {

--- a/packages/create-ai-blueprint/scripts/prepare-template.ts
+++ b/packages/create-ai-blueprint/scripts/prepare-template.ts
@@ -15,6 +15,16 @@ async function copyEntry(entry: string): Promise<void> {
   await fs.cp(source, target, { recursive: true });
 }
 
+// OpenCode reads .agents/skills natively, so its tree is mirrored rather than
+// kept as a third hand-edited copy that would drift from the other adapters.
+async function mirrorOpencodeSkills(): Promise<void> {
+  await fs.cp(
+    path.join(templateRoot, ".agents", "skills"),
+    path.join(templateRoot, ".opencode", "skills"),
+    { recursive: true }
+  );
+}
+
 async function main(): Promise<void> {
   await fs.rm(templateRoot, { recursive: true, force: true });
   await fs.mkdir(templateRoot, { recursive: true });
@@ -22,6 +32,8 @@ async function main(): Promise<void> {
   for (const entry of entries) {
     await copyEntry(entry);
   }
+
+  await mirrorOpencodeSkills();
 }
 
 main().catch((error: unknown) => {

--- a/packages/create-ai-blueprint/test/project-metadata.test.ts
+++ b/packages/create-ai-blueprint/test/project-metadata.test.ts
@@ -75,6 +75,25 @@ test("readProjectMetadata keeps Copilot distinct from Codex through the manifest
   assert.deepEqual(metadata.blueprint.adapters, ["copilot"]);
 });
 
+test("readProjectMetadata detects OpenCode from its skills directory", async (t) => {
+  const workspace = await createWorkspace(t);
+  const projectRoot = path.join(workspace, "app");
+
+  await fs.cp(fixtureRoot, projectRoot, { recursive: true });
+  await fs.rm(path.join(projectRoot, "blueprint", ".state", "manifest.json"));
+  await fs.mkdir(path.join(projectRoot, ".opencode", "skills", "check"), {
+    recursive: true
+  });
+  await fs.writeFile(
+    path.join(projectRoot, ".opencode", "skills", "check", "SKILL.md"),
+    "Check skill\n"
+  );
+
+  const metadata = await readProjectMetadata(projectRoot);
+
+  assert.ok(metadata.blueprint.adapters.includes("opencode"));
+});
+
 test("readProjectMetadata rejects paths outside a Blueprint project", async (t) => {
   const workspace = await createWorkspace(t);
 

--- a/packages/create-ai-blueprint/test/status.test.ts
+++ b/packages/create-ai-blueprint/test/status.test.ts
@@ -239,7 +239,7 @@ test("shouldUseColor requires a TTY and respects NO_COLOR", () => {
 });
 
 interface ProjectOptions {
-  adapters?: readonly ("claude" | "codex" | "copilot")[];
+  adapters?: readonly ("claude" | "codex" | "copilot" | "opencode")[];
   currentWork: string;
   findings: string;
   branch: string;

--- a/packages/create-ai-blueprint/test/update.test.ts
+++ b/packages/create-ai-blueprint/test/update.test.ts
@@ -28,7 +28,7 @@ import {
 test("parseArgs supports install and update modes", () => {
   assert.equal(
     ADAPTER_PROMPT,
-    "Install which adapter?\n1: Codex\n2: Claude Code\n3: GitHub Copilot\n4: all (default): "
+    "Install which adapter?\n1: Codex\n2: Claude Code\n3: GitHub Copilot\n4: OpenCode\n5: all (default): "
   );
   assert.equal(parseArgs([]).command, "install");
   assert.deepEqual(parseArgs(["update", "--dry-run"]), {
@@ -108,6 +108,7 @@ test("parseArgs supports install and update modes", () => {
     /--json is available only with the status command/
   );
   assert.equal(parseArgs(["--copilot"]).adapter, "copilot");
+  assert.equal(parseArgs(["--opencode"]).adapter, "opencode");
   assert.equal(parseArgs(["--all"]).adapter, "all");
   assert.deepEqual(parseArgs(["--both"]), {
     adapter: "all",
@@ -132,9 +133,9 @@ test("Copilot shares the .agents adapter files without managing Copilot instruct
   );
   assert.deepEqual(
     getTemplateEntries("all").map((entry) => entry.target),
-    ["AGENTS.md", "blueprint", ".agents", "CLAUDE.md", ".claude"]
+    ["AGENTS.md", "blueprint", ".agents", "CLAUDE.md", ".claude", ".opencode"]
   );
-  assert.deepEqual(adapterListFromMode("all"), ["codex", "claude", "copilot"]);
+  assert.deepEqual(adapterListFromMode("all"), ["codex", "claude", "copilot", "opencode"]);
 });
 
 test("global CLI installation is offered after interactive installs and updates", () => {
@@ -260,13 +261,51 @@ test("Copilot manifests remain distinct from Codex when they share skills", asyn
   assert.deepEqual(prepared.adapters, ["copilot"]);
 });
 
+test("OpenCode installs its own skills tree and stays distinct in the manifest", async (t) => {
+  assert.deepEqual(getTemplateEntries("opencode").map((entry) => entry.target), [
+    "AGENTS.md",
+    "blueprint",
+    ".opencode"
+  ]);
+
+  const workspace = await createWorkspace(t);
+  const templateRoot = path.join(workspace, "template");
+  const targetDir = path.join(workspace, "target");
+  const files = {
+    ".opencode/skills/check/SKILL.md": "Check skill\n"
+  };
+
+  await writeFiles(templateRoot, files);
+  await writeFiles(targetDir, files);
+  const manifest = await writeInstallManifest({
+    targetDir,
+    templateRoot,
+    version: "1.0.0",
+    adapter: "opencode"
+  });
+
+  assert.deepEqual(manifest.adapters, ["opencode"]);
+  assert.deepEqual(Object.keys(manifest.managedFiles), [
+    ".opencode/skills/check/SKILL.md"
+  ]);
+
+  const prepared = await prepareUpdate({
+    targetDir,
+    templateRoot,
+    version: "1.1.0"
+  });
+
+  assert.deepEqual(prepared.adapters, ["opencode"]);
+});
+
 test("updates preserve pre-Copilot Codex and Claude manifests", async (t) => {
   const workspace = await createWorkspace(t);
   const templateRoot = path.join(workspace, "template");
   const targetDir = path.join(workspace, "target");
   const files = {
     ".agents/skills/check/SKILL.md": "Check skill\n",
-    ".claude/skills/check/SKILL.md": "Check skill\n"
+    ".claude/skills/check/SKILL.md": "Check skill\n",
+    ".opencode/skills/check/SKILL.md": "Check skill\n"
   };
 
   await writeFiles(templateRoot, files);

--- a/scripts/smoke-package.ts
+++ b/scripts/smoke-package.ts
@@ -9,7 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const packageRoot = path.join(repoRoot, "packages", "create-ai-blueprint");
 
-type Adapter = "codex" | "claude" | "copilot";
+type Adapter = "codex" | "claude" | "copilot" | "opencode";
 
 interface PackageManifest {
   schemaVersion: number;
@@ -19,12 +19,13 @@ interface PackageManifest {
 }
 
 const modes: Record<string, Adapter[]> = {
-  default: ["codex", "claude", "copilot"],
+  default: ["codex", "claude", "copilot", "opencode"],
   codex: ["codex"],
   claude: ["claude"],
   copilot: ["copilot"],
-  all: ["codex", "claude", "copilot"],
-  both: ["codex", "claude", "copilot"]
+  opencode: ["opencode"],
+  all: ["codex", "claude", "copilot", "opencode"],
+  both: ["codex", "claude", "copilot", "opencode"]
 };
 
 function getErrorCode(error: unknown): string | undefined {
@@ -52,7 +53,10 @@ function parseManifest(content: string): PackageManifest {
     !Array.isArray(manifest.adapters) ||
     !manifest.adapters.every(
       (adapter): adapter is Adapter =>
-        adapter === "codex" || adapter === "claude" || adapter === "copilot"
+        adapter === "codex" ||
+        adapter === "claude" ||
+        adapter === "copilot" ||
+        adapter === "opencode"
     ) ||
     typeof manifest.managedFiles !== "object" ||
     manifest.managedFiles === null ||
@@ -251,9 +255,17 @@ async function main(): Promise<void> {
       }
 
       if (
+        mode === "opencode" &&
+        (!installResult.stdout.includes("Ask OpenCode to run the onboard skill.") ||
+          installResult.stdout.includes("Claude Code:"))
+      ) {
+        throw new Error("opencode install did not print OpenCode-specific guidance");
+      }
+
+      if (
         (mode === "all" || mode === "both" || mode === "default") &&
         !installResult.stdout.includes(
-          "$onboard, /onboard, or ask Copilot to run the onboard skill."
+          "$onboard, /onboard, or ask Copilot or OpenCode to run the onboard skill."
         )
       ) {
         throw new Error(`${mode} install did not print all-adapter guidance`);
@@ -378,7 +390,7 @@ async function main(): Promise<void> {
     }
 
     console.log(
-      "Packed installer passed for the default, Codex, Claude Code, GitHub Copilot, all, and both adapter modes."
+      "Packed installer passed for the default, Codex, Claude Code, GitHub Copilot, OpenCode, all, and both adapter modes."
     );
   } finally {
     await fs.rm(workspace, { recursive: true, force: true });
@@ -393,6 +405,7 @@ async function validateInstall(
   const expectsCodex = adapters.includes("codex");
   const expectsClaude = adapters.includes("claude");
   const expectsCopilot = adapters.includes("copilot");
+  const expectsOpencode = adapters.includes("opencode");
   const expectsSharedSkills = expectsCodex || expectsCopilot;
   const expectedPaths = [
     "AGENTS.md",
@@ -420,6 +433,14 @@ async function validateInstall(
     );
   }
 
+  if (expectsOpencode) {
+    expectedPaths.push(
+      ".opencode/skills/discovery/SKILL.md",
+      ".opencode/skills/onboard/SKILL.md",
+      ".opencode/skills/rollback/SKILL.md"
+    );
+  }
+
   for (const relativePath of expectedPaths) {
     await requirePath(path.join(targetDir, ...relativePath.split("/")));
   }
@@ -435,6 +456,10 @@ async function validateInstall(
   if (!expectsClaude) {
     await requireMissing(path.join(targetDir, ".claude"));
     await requireMissing(path.join(targetDir, "CLAUDE.md"));
+  }
+
+  if (!expectsOpencode) {
+    await requireMissing(path.join(targetDir, ".opencode"));
   }
 
   const manifest = parseManifest(
@@ -475,6 +500,14 @@ async function validateInstall(
     expectedManagedFiles.push(
       ...(await listFiles(path.join(targetDir, ".claude", "skills"))).map(
         (file) => `.claude/skills/${file}`
+      )
+    );
+  }
+
+  if (expectsOpencode) {
+    expectedManagedFiles.push(
+      ...(await listFiles(path.join(targetDir, ".opencode", "skills"))).map(
+        (file) => `.opencode/skills/${file}`
       )
     );
   }


### PR DESCRIPTION
## What

Adds OpenCode as an explicit adapter, matching the shape of the GitHub Copilot
adapter from #4.

- `--opencode` installs `AGENTS.md`, `.opencode/`, and `blueprint/`
- `--all` now covers Codex, Claude Code, GitHub Copilot, and OpenCode
- Interactive prompt gains OpenCode as option 4, so `all` moves to 5
- The manifest tracks `opencode` as its own adapter, so `update` and
  `blueprint status` report it correctly

## Why this shape

OpenCode reads `AGENTS.md` for project instructions and discovers skills from
`.opencode/skills/<name>/SKILL.md`
([docs](https://opencode.ai/docs/skills)). It also reads `.agents/skills` and
`.claude/skills` natively, so the existing adapters already work in OpenCode.
This PR adds the explicit adapter anyway for the same reason Copilot has one:
a clear install flag, a distinct manifest entry, and tool-specific next-step
guidance.

The `.opencode/skills` tree is mirrored from `.agents/skills` in
`prepare-template.ts` at pack time rather than committed as a third copy, so
there is no extra tree for maintainers to keep in sync. Verified at 28 files in
both trees.

## Verification

- `npm run typecheck` clean
- `npm run check:static` passes, 21 skills, 28 adapter files
- `npm run test:routing` passes, rank-one 97%
- `npm run test:package` passes for default, codex, claude, copilot, opencode,
  all, and both modes, including new presence, absence, and manifest assertions
  for `.opencode/`
- Installer unit tests add coverage for the `opencode` template entries,
  manifest, and filesystem detection
- Installed a local build into a scratch project and confirmed all 21
  `SKILL.md` files satisfy OpenCode's frontmatter rules (name matches directory,
  valid slug, description under the 1024 character cap)

## Notes

- `scripts/e2e/harness.ts` still drives only `claude` and `copilot`. Adding
  OpenCode there needs a real `opencode` CLI invocation and felt like separate
  scope. The `--all` path it already exercises covers the new adapter.
- `--both` remains a deprecated alias for `--all`, unchanged.