### PR TITLE
fix: quote Windows package smoke command

### DIFF
--- a/scripts/smoke-package.ts
+++ b/scripts/smoke-package.ts
@@ -224,7 +224,8 @@ async function main(): Promise<void> {
 
     for (const [mode, config] of Object.entries(modes)) {
       const { adapters, flags } = config;
-      const targetDir = path.join(workspace, `target-${mode}`);
+      const targetName = `target-${mode} with spaces`;
+      const targetDir = path.join(workspace, targetName);
       await fs.mkdir(targetDir, { recursive: true });
       const installResult = run(
         process.execPath,
@@ -310,7 +311,7 @@ async function main(): Promise<void> {
         true
       );
 
-      if (!statusResult.stdout.includes(`Blueprint Status  target-${mode}`)) {
+      if (!statusResult.stdout.includes(`Blueprint Status  ${targetName}`)) {
         throw new Error(`${mode} status smoke test did not identify the project`);
       }
 
@@ -325,7 +326,7 @@ async function main(): Promise<void> {
         true
       );
 
-      if (!blueprintStatusResult.stdout.includes(`Blueprint Status  target-${mode}`)) {
+      if (!blueprintStatusResult.stdout.includes(`Blueprint Status  ${targetName}`)) {
         throw new Error(`${mode} blueprint alias did not report project status`);
       }
 
@@ -566,7 +567,8 @@ function run(
   command: string,
   args: readonly string[],
   cwd: string,
-  capture = false
+  capture = false,
+  windowsVerbatimArguments = false
 ) {
   const result = spawnSync(command, args, {
     cwd,
@@ -577,7 +579,8 @@ function run(
       npm_config_fund: "false",
       npm_config_update_notifier: "false"
     },
-    stdio: capture ? "pipe" : "inherit"
+    stdio: capture ? "pipe" : "inherit",
+    windowsVerbatimArguments
   });
 
   if (result.error) {
@@ -619,10 +622,20 @@ function runInstalledCommand(
 
   return run(
     process.env.ComSpec || "cmd.exe",
-    ["/d", "/s", "/c", `"${command}" ${args.join(" ")}`],
+    [
+      "/d",
+      "/s",
+      "/c",
+      `call "${command}" ${args.map(quoteForCmd).join(" ")}`
+    ],
     cwd,
-    capture
+    capture,
+    true
   );
+}
+
+function quoteForCmd(argument: string): string {
+  return `"${argument.replaceAll('"', '""')}"`;
 }
 
 async function requirePath(filePath: string): Promise<void> {


### PR DESCRIPTION
## Summary

`npm run test:package` cannot pass on Windows. `runInstalledCommand` hands `cmd.exe` a single pre-quoted string:

```ts
["/d", "/s", "/c", `"${command}" ${args.join(" ")}`]
```

Node then applies its own Windows argument escaping on top, so the quotes arrive at `cmd.exe` as `\"` and the shim is never resolved:

```text
'\"D:\...\node_modules\.bin\create-ai-blueprint.cmd\"' is not recognized as an
internal or external command, operable program or batch file.
```

This reproduces on unmodified `main`, so the smoke test, and therefore `npm run check`, is currently unrunnable on Windows. That also makes `npm run check` in CONTRIBUTING.md unachievable for Windows contributors.

The change does four things:

1. Threads `windowsVerbatimArguments` through `run`, so Node passes the command line to `cmd.exe` exactly as constructed instead of re-escaping it.
2. Invokes the shim as `call "<command>"`, which is the correct way to run a `.cmd` shim from `cmd.exe /c`.
3. Quotes each argument through a new `quoteForCmd` helper that doubles embedded quotes.
4. Names the smoke target directory `target-<mode> with spaces`, so the suite exercises paths containing spaces rather than avoiding them.

POSIX behavior is unchanged. The non-Windows path still calls `run(command, args, cwd, capture)`, and `windowsVerbatimArguments` defaults to `false`.

## Validation

```text
npm run test:package     pass, default, individual, combined, all, and legacy both adapter modes
npm run typecheck        pass
```

Before and after, on Windows 11 with Node v24.19.0 and npm 12.0.2:

```text
main, unmodified                      fail, error above
main, plus only the space in the dir   fail, identical error
this branch                            pass, all five adapter modes
```

`npm run check` runs five checks and stops at the first failure. On this branch it stops at check four, "Installer unit tests", because of a separate pre-existing Windows path-separator bug that this branch does not touch. That bug is fixed in aiblueprinthq/ai-blueprint#10. With this branch and #10 and #9 stacked locally, the complete gate passes:

```text
[check] Static Blueprint contract        pass, 22 skills, 29 adapter files, 5 Claude imports, 4 skill references
[check] Skill routing evaluations        pass
[check] Sandbox runner unit tests        pass
[check] Installer unit tests             pass
[check] Packed installer smoke tests     pass
AI Blueprint validation passed.
```

## Checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Shared skill changes are synchronized across `.agents/skills/` and `.claude/skills/`. Not applicable, no skill files changed.
- [x] User-facing behavior is reflected in the root and package documentation where needed. Not applicable, this is a maintainer script.
- [x] `npm run check` passes locally, when stacked with #10 which fixes the unrelated check-four failure. Output above.
- [x] No secrets, credentials, private code, or personal data are included.
- [x] Package version and release notes are updated when the change is intended for publication. Not applicable. CONTRIBUTING.md documents `scripts/` as maintainer files that are not copied into applications, and the changelog tracks published `create-ai-blueprint` releases, so this fix is not a release note.
