### PR TITLE
feat: harden complete and rollback safeguards

### DIFF
--- a/.agents/skills/complete/SKILL.md
+++ b/.agents/skills/complete/SKILL.md
@@ -115,9 +115,15 @@ entries keep their recorded reason). Prefix each ID with the archive name for
 global uniqueness: feature 12's `F-03` becomes `12/F-03`; fixes and rollbacks
 use their archive filename as the prefix. An entry carried forward from earlier
 work archives with the item that resolved it; its **Found** line preserves
-where it came from. Then remove the archived entries from the ledger. Unresolved entries (`open` or `fixed` P2/P3, and `unverified`
-leads) stay in the ledger with their IDs so they are never silently dropped.
-When nothing remains, reset the ledger to exactly this stub, and create it the
+where it came from. Only `closed`, `accepted`, and `invalid` entries are
+resolved for archival. A `fixed` entry is not resolved at any severity: never
+append it to the archive or remove it from the live ledger.
+
+Then remove only the archived entries from the ledger. Entries with `open`,
+`fixed`, or `unverified` status stay in the ledger with their IDs so they are
+never silently dropped. A fixed P2/P3 finding does not block completion, but it
+must remain verbatim for a later `/audit` re-review. When no `open`, `fixed`, or
+`unverified` entries remain, reset the ledger to exactly this stub, and create it the
 same way if the file is missing (an older install):
 
     # Findings
@@ -131,10 +137,28 @@ same way if the file is missing (an older install):
 
     _No findings recorded. `/audit` appends findings here when it finds them._
 
-Then reset `blueprint/context/current-feature.md` to its current stub ("nothing
-in progress"), including `/rollback` alongside `/feature` and `/fix`. Don't
-commit yet; the next step makes one work commit covering the code and these doc
-changes. The archive is the build history.
+Keep every unresolved entry in the ledger. Do not replace it with the empty stub
+while it still contains any open, fixed, or unverified finding. After archiving
+resolved findings, replace `blueprint/context/current-feature.md` with
+the canonical stub below. Do not paraphrase it or substitute an abbreviated "no
+work" stub. Before committing, read the file and confirm it exactly matches:
+
+    # Current Feature
+
+    > **Generated file.** Holds the one feature, fix, or rollback being built right now. Run
+    > `/feature <number-or-name>` to spec a build-plan feature, or `/fix "<bug>"` for
+    > an ad-hoc fix. Use `/rollback <completed-feature>` to plan a safe reversal.
+    > Build one thing at a time; `/complete` archives it under
+    > `blueprint/history/` and resets this file.
+
+    _Nothing in progress. Run `/feature`, `/fix`, or `/rollback` to start._
+
+When no open, fixed, or unverified ledger entries remain, confirm
+`blueprint/context/findings.md` exactly matches the canonical Findings stub
+above. Otherwise, preserve the remaining entries without rewriting them.
+
+Don't commit yet; the next step makes one work commit covering the code and these
+documentation changes. The archive is the build history.
 
 **Discard consumed prototypes.** If this feature built the look from `prototypes/`
 - its Design reference pointed there and an early step ported `prototypes/theme.css`

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -66,17 +66,21 @@ spec. Reversing the whole commit would damage that state.
 
 Before the first rollback build step:
 
-1. Re-resolve the target archive's introducing commit and confirm it matches the
-   full Target commit SHA recorded in the approved spec.
-2. Confirm the target is an ancestor of `HEAD`, has the recorded single parent,
-   and the only dirty path before applying the patch is the approved rollback
-   spec. Stop on drift.
-3. Preview the target's product diff while excluding `.agents/**`, `.claude/**`,
+1. Read the approved spec's `Target commit` and `Target parent` fields. Stop
+   unless both values match `^[0-9a-f]{40}$`. Do not accept abbreviated,
+   uppercase, or otherwise malformed SHAs.
+2. Resolve the archive's introducing commit and verify it has exactly one parent.
+   Stop on a merge target. Resolve that single parent to a full SHA value.
+   Confirm the resolved commit exactly equals `Target commit` and the resolved
+   parent exactly equals `Target parent`. Stop on any mismatch.
+3. Confirm the resolved target is an ancestor of `HEAD` and the only dirty path
+   before applying the patch is the approved rollback spec. Stop on drift.
+4. Preview the resolved target's product diff while excluding `.agents/**`, `.claude/**`,
    `blueprint/**`, `AGENTS.md`, `CLAUDE.md`, and
    `prototypes/**`. Confirm the preview is non-empty and matches the Product
    paths in the spec.
-4. Apply that product diff in reverse with three-way conflict detection and
-   stage it. Substitute the two approved full SHAs before running:
+5. Apply that resolved product diff in reverse with three-way conflict detection
+   and stage it. Use only the resolved full SHA values before running:
 
        git diff --binary <target-parent> <target-commit> -- . \
          ':(exclude).agents/**' \
@@ -86,7 +90,7 @@ Before the first rollback build step:
          git apply --reverse --3way --index
 
    Never omit the protected pathspec exclusions for convenience.
-5. Show both `git diff --cached` and `git status`. Confirm no protected path is
+6. Show both `git diff --cached` and `git status`. Confirm no protected path is
    staged or modified before presenting the step for review.
 
 If the reverse patch conflicts, stop and report the exact paths and later commit

--- a/.agents/skills/rollback/SKILL.md
+++ b/.agents/skills/rollback/SKILL.md
@@ -59,9 +59,11 @@ Use the archive path to locate the commit that added it:
     git log --diff-filter=A --format="%H %s" HEAD -- <archive-path>
 
 Use the newest matching commit reachable from the current branch. Confirm the
-archive was added by that commit, the commit has exactly one parent, and its
-subject and diff are consistent with the requested feature. A merge commit needs
-mainline selection, so stop rather than guessing. If the archive was never
+archive was added by that commit and its subject and diff are consistent with the
+requested feature. If the target is a merge commit, record its first parent as
+the traceable `Target parent` in the rollback spec and name the merge target as
+an implementation blocker. Do not choose a mainline or attempt a product reversal:
+`/implement` stops before applying a merge target. If the archive was never
 committed, explain that git cannot reconstruct a safe rollback from it.
 
 ## Step 2 - separate product changes from Blueprint history
@@ -110,7 +112,8 @@ remediation or explicitly plan the dependent rollbacks.
 Write `blueprint/context/current-feature.md` using
 `reference/rollback-spec-template.md`. Fill in:
 
-- target feature, archive, exact commit, and parent commit
+- target feature and archive
+- target commit and parent commit as full 40-character SHA values
 - user's reason
 - product paths introduced or changed by the target
 - protected workflow paths
@@ -144,6 +147,8 @@ spec, then run `/implement` to create the rollback branch and apply it.
 - Preserve history. Never delete or rewrite the original feature archive.
 - Plan only. This skill writes the rollback spec and nothing else.
 - One completed feature per rollback.
+- Record both the target commit and its parent as full 40-character SHA values.
+  Each value must resolve to the recorded commit in the current repository.
 - Never use `git reset --hard`, force-push, history rewriting, or broad file
   restoration.
 - Never infer permission to cascade into later features or destroy stored data.

--- a/.agents/skills/rollback/reference/rollback-spec-template.md
+++ b/.agents/skills/rollback/reference/rollback-spec-template.md
@@ -3,8 +3,8 @@
 **Type:** Rollback
 **Target feature:** NN - Name
 **Target archive:** `blueprint/history/features/NN-name.md`
-**Target commit:** `<full commit SHA>`
-**Target parent:** `<full parent SHA>`
+**Target commit:** `<full 40-character commit SHA>`
+**Target parent:** `<full 40-character parent SHA>`
 **Reason:** Why this completed feature must be removed
 
 ## Goal

--- a/.claude/skills/complete/SKILL.md
+++ b/.claude/skills/complete/SKILL.md
@@ -115,9 +115,15 @@ entries keep their recorded reason). Prefix each ID with the archive name for
 global uniqueness: feature 12's `F-03` becomes `12/F-03`; fixes and rollbacks
 use their archive filename as the prefix. An entry carried forward from earlier
 work archives with the item that resolved it; its **Found** line preserves
-where it came from. Then remove the archived entries from the ledger. Unresolved entries (`open` or `fixed` P2/P3, and `unverified`
-leads) stay in the ledger with their IDs so they are never silently dropped.
-When nothing remains, reset the ledger to exactly this stub, and create it the
+where it came from. Only `closed`, `accepted`, and `invalid` entries are
+resolved for archival. A `fixed` entry is not resolved at any severity: never
+append it to the archive or remove it from the live ledger.
+
+Then remove only the archived entries from the ledger. Entries with `open`,
+`fixed`, or `unverified` status stay in the ledger with their IDs so they are
+never silently dropped. A fixed P2/P3 finding does not block completion, but it
+must remain verbatim for a later `/audit` re-review. When no `open`, `fixed`, or
+`unverified` entries remain, reset the ledger to exactly this stub, and create it the
 same way if the file is missing (an older install):
 
     # Findings
@@ -131,10 +137,28 @@ same way if the file is missing (an older install):
 
     _No findings recorded. `/audit` appends findings here when it finds them._
 
-Then reset `blueprint/context/current-feature.md` to its current stub ("nothing
-in progress"), including `/rollback` alongside `/feature` and `/fix`. Don't
-commit yet; the next step makes one work commit covering the code and these doc
-changes. The archive is the build history.
+Keep every unresolved entry in the ledger. Do not replace it with the empty stub
+while it still contains any open, fixed, or unverified finding. After archiving
+resolved findings, replace `blueprint/context/current-feature.md` with
+the canonical stub below. Do not paraphrase it or substitute an abbreviated "no
+work" stub. Before committing, read the file and confirm it exactly matches:
+
+    # Current Feature
+
+    > **Generated file.** Holds the one feature, fix, or rollback being built right now. Run
+    > `/feature <number-or-name>` to spec a build-plan feature, or `/fix "<bug>"` for
+    > an ad-hoc fix. Use `/rollback <completed-feature>` to plan a safe reversal.
+    > Build one thing at a time; `/complete` archives it under
+    > `blueprint/history/` and resets this file.
+
+    _Nothing in progress. Run `/feature`, `/fix`, or `/rollback` to start._
+
+When no open, fixed, or unverified ledger entries remain, confirm
+`blueprint/context/findings.md` exactly matches the canonical Findings stub
+above. Otherwise, preserve the remaining entries without rewriting them.
+
+Don't commit yet; the next step makes one work commit covering the code and these
+documentation changes. The archive is the build history.
 
 **Discard consumed prototypes.** If this feature built the look from `prototypes/`
 - its Design reference pointed there and an early step ported `prototypes/theme.css`

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -66,17 +66,21 @@ spec. Reversing the whole commit would damage that state.
 
 Before the first rollback build step:
 
-1. Re-resolve the target archive's introducing commit and confirm it matches the
-   full Target commit SHA recorded in the approved spec.
-2. Confirm the target is an ancestor of `HEAD`, has the recorded single parent,
-   and the only dirty path before applying the patch is the approved rollback
-   spec. Stop on drift.
-3. Preview the target's product diff while excluding `.agents/**`, `.claude/**`,
+1. Read the approved spec's `Target commit` and `Target parent` fields. Stop
+   unless both values match `^[0-9a-f]{40}$`. Do not accept abbreviated,
+   uppercase, or otherwise malformed SHAs.
+2. Resolve the archive's introducing commit and verify it has exactly one parent.
+   Stop on a merge target. Resolve that single parent to a full SHA value.
+   Confirm the resolved commit exactly equals `Target commit` and the resolved
+   parent exactly equals `Target parent`. Stop on any mismatch.
+3. Confirm the resolved target is an ancestor of `HEAD` and the only dirty path
+   before applying the patch is the approved rollback spec. Stop on drift.
+4. Preview the resolved target's product diff while excluding `.agents/**`, `.claude/**`,
    `blueprint/**`, `AGENTS.md`, `CLAUDE.md`, and
    `prototypes/**`. Confirm the preview is non-empty and matches the Product
    paths in the spec.
-4. Apply that product diff in reverse with three-way conflict detection and
-   stage it. Substitute the two approved full SHAs before running:
+5. Apply that resolved product diff in reverse with three-way conflict detection
+   and stage it. Use only the resolved full SHA values before running:
 
        git diff --binary <target-parent> <target-commit> -- . \
          ':(exclude).agents/**' \
@@ -86,7 +90,7 @@ Before the first rollback build step:
          git apply --reverse --3way --index
 
    Never omit the protected pathspec exclusions for convenience.
-5. Show both `git diff --cached` and `git status`. Confirm no protected path is
+6. Show both `git diff --cached` and `git status`. Confirm no protected path is
    staged or modified before presenting the step for review.
 
 If the reverse patch conflicts, stop and report the exact paths and later commit

--- a/.claude/skills/rollback/SKILL.md
+++ b/.claude/skills/rollback/SKILL.md
@@ -59,9 +59,11 @@ Use the archive path to locate the commit that added it:
     git log --diff-filter=A --format="%H %s" HEAD -- <archive-path>
 
 Use the newest matching commit reachable from the current branch. Confirm the
-archive was added by that commit, the commit has exactly one parent, and its
-subject and diff are consistent with the requested feature. A merge commit needs
-mainline selection, so stop rather than guessing. If the archive was never
+archive was added by that commit and its subject and diff are consistent with the
+requested feature. If the target is a merge commit, record its first parent as
+the traceable `Target parent` in the rollback spec and name the merge target as
+an implementation blocker. Do not choose a mainline or attempt a product reversal:
+`/implement` stops before applying a merge target. If the archive was never
 committed, explain that git cannot reconstruct a safe rollback from it.
 
 ## Step 2 - separate product changes from Blueprint history
@@ -110,7 +112,8 @@ remediation or explicitly plan the dependent rollbacks.
 Write `blueprint/context/current-feature.md` using
 `reference/rollback-spec-template.md`. Fill in:
 
-- target feature, archive, exact commit, and parent commit
+- target feature and archive
+- target commit and parent commit as full 40-character SHA values
 - user's reason
 - product paths introduced or changed by the target
 - protected workflow paths
@@ -144,6 +147,8 @@ spec, then run `/implement` to create the rollback branch and apply it.
 - Preserve history. Never delete or rewrite the original feature archive.
 - Plan only. This skill writes the rollback spec and nothing else.
 - One completed feature per rollback.
+- Record both the target commit and its parent as full 40-character SHA values.
+  Each value must resolve to the recorded commit in the current repository.
 - Never use `git reset --hard`, force-push, history rewriting, or broad file
   restoration.
 - Never infer permission to cascade into later features or destroy stored data.

--- a/.claude/skills/rollback/reference/rollback-spec-template.md
+++ b/.claude/skills/rollback/reference/rollback-spec-template.md
@@ -3,8 +3,8 @@
 **Type:** Rollback
 **Target feature:** NN - Name
 **Target archive:** `blueprint/history/features/NN-name.md`
-**Target commit:** `<full commit SHA>`
-**Target parent:** `<full parent SHA>`
+**Target commit:** `<full 40-character commit SHA>`
+**Target parent:** `<full 40-character parent SHA>`
 **Reason:** Why this completed feature must be removed
 
 ## Goal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ published `create-ai-blueprint` package.
 
 ## Unreleased
 
+### Changed
+
+- Required `/rollback` to record the target commit and its parent as full
+  40-character SHA values, and to treat a merge target as an implementation
+  blocker instead of selecting a mainline.
+- Required `/implement` to validate both recorded SHAs, confirm a single parent,
+  confirm the target is an ancestor of `HEAD`, and require a clean tree before
+  reverse-applying a rollback patch.
+- Stopped `/complete` from archiving or removing a `fixed` finding at any
+  severity, so repaired findings remain in the ledger for a later `/audit`
+  re-review.
+
+### Fixed
+
+- Pinned the canonical `current-feature.md` and `findings.md` stubs so
+  `/complete` can no longer reset them to paraphrased content.
+
 ## [0.14.0] - 2026-08-25
 
 ### Added

--- a/scripts/e2e/scenarios/ledger-gate.ts
+++ b/scripts/e2e/scenarios/ledger-gate.ts
@@ -25,6 +25,26 @@ const FINDINGS_STUB = `# Findings
 _No findings recorded. \`/audit\` appends findings here when it finds them._
 `;
 const normalizeLineEndings = (content: string | null) => content?.replace(/\r\n/g, "\n") ?? "";
+interface ArchivedFinding {
+  id: string;
+  status: string;
+}
+
+function parseArchiveFindings(archive: string): ArchivedFinding[] {
+  const findingsHeader = /^## Findings\r?$/m.exec(archive);
+
+  if (!findingsHeader || findingsHeader.index === undefined) {
+    return [];
+  }
+
+  const afterHeader = archive.slice(findingsHeader.index + findingsHeader[0].length);
+  const nextSection = afterHeader.search(/\r?\n## /);
+  const findingsSection = nextSection === -1 ? afterHeader : afterHeader.slice(0, nextSection);
+
+  return [...findingsSection.matchAll(
+    /^### (?:[^\s/]+\/)?(F-\d{2}) \[P[0-3]\] (unverified|open|fixed|closed|accepted|invalid) - /gm
+  )].map((match) => ({ id: match[1], status: match[2] }));
+}
 
 const FIX_SPEC = `# Current Feature
 
@@ -71,6 +91,39 @@ const CLOSED_FINDING = OPEN_FINDING.replace(
   "**Resolution:**",
   "**Resolution:** Verified 2026-07-22 by /audit re-review: command output shows \"Hello, world!\" and the repair introduced no new defect."
 );
+const UNRESOLVED_FINDINGS = `### F-02 [P2] open - Legacy greeting helper has no focused test
+
+**File:** src/greeting.js:2
+**Found:** 2026-07-22 by /audit (scope: current)
+**Why it matters:** A future refactor could change the helper without a focused
+assertion documenting its expected output.
+**Suggested fix:** Add a focused assertion when unit testing is configured.
+**Resolution:**
+
+### F-03 [P2] fixed - Greeting output repair needs audit re-review
+
+**File:** src/greeting.js:2
+**Found:** 2026-07-22 by /audit (scope: current)
+**Why it matters:** The repair must be independently reviewed before it can close.
+**Suggested fix:** Run /audit after the focused assertion is added.
+**Resolution:** Repaired 2026-07-22 by /implement.
+
+### F-04 [P3] fixed - Greeting helper naming is inconsistent
+
+**File:** src/greeting.js:2
+**Found:** 2026-07-22 by /audit (scope: current)
+**Why it matters:** The name is less clear than the surrounding helpers.
+**Suggested fix:** Rename it during a scoped cleanup.
+**Resolution:** Renamed 2026-07-22 by /implement.
+
+### F-05 [P3] unverified - Legacy greeting output may be unused
+
+**File:** src/greeting.js:2
+**Found:** 2026-07-22 by /audit (scope: current)
+**Why it matters:** The helper may be dead code, but no source evidence confirms it.
+**Suggested fix:** Re-examine the project before removing it.
+**Resolution:**
+`;
 
 async function run(t: Runner) {
   t.phase("setup");
@@ -123,8 +176,8 @@ async function run(t: Runner) {
   t.check("F-01 still open in the ledger", (t.read("blueprint/context/findings.md") || "").includes("[P1] open"));
   t.check("agent names F-01 as the blocker", blocked.resultText.includes("F-01"));
 
-  t.phase("approved merge: /complete proceeds once F-01 is closed");
-  t.write("blueprint/context/findings.md", CLOSED_FINDING);
+  t.phase("approved merge: /complete archives F-01 and preserves unresolved findings");
+  t.write("blueprint/context/findings.md", `${CLOSED_FINDING}\n${UNRESOLVED_FINDINGS}`);
   t.git("checkout", "fix/greeting-punctuation");
   const merged = t.agent(
     "Run /complete for the current fix. You have my explicit approval to squash-merge to main and delete the branch. Do not push anywhere."
@@ -138,15 +191,58 @@ async function run(t: Runner) {
   const archiveList = t.git("ls-tree", "-r", "--name-only", "main", "blueprint/history/fixes");
   const archiveFile = archiveList.split("\n").find((file) => file.endsWith(".md") && !file.endsWith("README.md"));
   const archive = archiveFile ? t.git("show", `main:${archiveFile}`) : "";
+  const archiveFindings = parseArchiveFindings(archive);
   t.check("fix archive exists", Boolean(archiveFile));
-  t.check("archive carries F-01 at closed", archive.includes("F-01") && archive.includes("closed"));
+  t.check(
+    "archive carries F-01 at closed",
+    archiveFindings.some((finding) => finding.id === "F-01" && finding.status === "closed")
+  );
+  t.check(
+    "archive excludes unresolved fixed P2/P3 findings",
+    !archiveFindings.some((finding) => finding.id === "F-03" || finding.id === "F-04")
+  );
+  t.check(
+    "archive excludes unresolved open and unverified findings",
+    !archiveFindings.some((finding) => finding.id === "F-02" || finding.id === "F-05")
+  );
   t.check(
     "spec reset to the canonical stub",
     normalizeLineEndings(t.read("blueprint/context/current-feature.md")) === CURRENT_FEATURE_STUB
   );
   t.check(
-    "ledger reset to the canonical stub",
-    normalizeLineEndings(t.read("blueprint/context/findings.md")) === FINDINGS_STUB
+    "unresolved open P2 finding remains unchanged in the ledger",
+    normalizeLineEndings(t.read("blueprint/context/findings.md")).includes(
+      UNRESOLVED_FINDINGS.slice(0, UNRESOLVED_FINDINGS.indexOf("\n\n### F-03"))
+    )
+  );
+  t.check(
+    "unresolved fixed P2 finding remains unchanged in the ledger",
+    normalizeLineEndings(t.read("blueprint/context/findings.md")).includes(
+      UNRESOLVED_FINDINGS.slice(
+        UNRESOLVED_FINDINGS.indexOf("### F-03"),
+        UNRESOLVED_FINDINGS.indexOf("\n\n### F-04")
+      )
+    )
+  );
+  t.check(
+    "unresolved fixed P3 finding remains unchanged in the ledger",
+    normalizeLineEndings(t.read("blueprint/context/findings.md")).includes(
+      UNRESOLVED_FINDINGS.slice(
+        UNRESOLVED_FINDINGS.indexOf("### F-04"),
+        UNRESOLVED_FINDINGS.indexOf("\n\n### F-05")
+      )
+    )
+  );
+  t.check(
+    "unresolved unverified finding remains unchanged in the ledger",
+    normalizeLineEndings(t.read("blueprint/context/findings.md")).includes(
+      UNRESOLVED_FINDINGS.slice(UNRESOLVED_FINDINGS.indexOf("### F-05"))
+    )
+  );
+  t.check(
+    "ledger does not retain archived F-01 or reset to the empty stub",
+    !normalizeLineEndings(t.read("blueprint/context/findings.md")).includes("### F-01") &&
+      normalizeLineEndings(t.read("blueprint/context/findings.md")) !== FINDINGS_STUB
   );
 
   t.phase("lazy-create: /audit rebuilds a deleted ledger in valid format");

--- a/scripts/e2e/scenarios/rollback-plan.ts
+++ b/scripts/e2e/scenarios/rollback-plan.ts
@@ -15,6 +15,23 @@ Change the default output from \`Hello world\` to \`Hello, world!\`.
 
 \`node src/greeting.js\` printed \`Hello, world!\`.
 `;
+const MERGE_FEATURE_ARCHIVE = `# Feature 2: Merge target
+
+**Type:** Feature
+**Status:** Complete
+
+## Goal
+
+Add a greeting helper through a merge commit.
+
+## Build steps
+
+- [x] 1. Add \`src/merge-greeting.js\`.
+
+## Verification
+
+\`node src/merge-greeting.js\` printed \`Hello from the merge target\`.
+`;
 
 import type { Runner } from "../harness.js";
 
@@ -46,6 +63,12 @@ async function run(t: Runner) {
     "Run /rollback 1 because the punctuation breaks a strict downstream consumer. Plan it and stop for review."
   );
   const rollbackSpec = t.read("blueprint/context/current-feature.md") || "";
+  const targetCommit = rollbackSpec.match(
+    /^\*\*Target commit:\*\*\s*`?([0-9a-f]{40})`?\s*$/im
+  )?.[1];
+  const targetParent = rollbackSpec.match(
+    /^\*\*Target parent:\*\*\s*`?([0-9a-f]{40})`?\s*$/im
+  )?.[1];
   const changedPaths = t
     .git("status", "--porcelain")
     .split("\n")
@@ -61,12 +84,79 @@ async function run(t: Runner) {
     t.read("blueprint/history/features/01-greeting-punctuation.md") === archiveBefore
   );
   t.check("a rollback spec was written", /^\*\*Type:\*\*\s*Rollback\s*$/im.test(rollbackSpec));
-  t.check("the spec records the exact feature commit", rollbackSpec.includes(featureCommit));
-  t.check("the spec records the exact feature parent", rollbackSpec.includes(featureParent));
+  t.check(
+    "the spec records the exact 40-character feature commit",
+    targetCommit === featureCommit
+  );
+  t.check(
+    "the spec records the exact 40-character feature parent",
+    targetParent === featureParent
+  );
   t.check("the spec records the user's reason", /downstream consumer/i.test(rollbackSpec));
   t.check(
     "only the current feature spec changed",
     changedPaths.length === 1 && changedPaths[0] === "blueprint/context/current-feature.md"
+  );
+
+  t.phase("rollback plans a merge target for implementation review");
+  t.git("restore", "blueprint/context/current-feature.md");
+  t.write(
+    "blueprint/build-plan.md",
+    "# Build Plan\n\n- [x] 1. Greeting punctuation\n- [ ] 2. Merge target\n"
+  );
+  t.git("add", "-A");
+  t.git("commit", "-m", "chore: prepare merge rollback target");
+  t.git("checkout", "-b", "feature/merge-target");
+  t.write("src/merge-greeting.js", 'console.log("Hello from the merge target");\n');
+  t.git("add", "-A");
+  t.git("commit", "-m", "feat: stage merge target product");
+  t.git("checkout", "main");
+  t.git("merge", "--no-ff", "--no-commit", "feature/merge-target");
+  t.write(
+    "blueprint/build-plan.md",
+    "# Build Plan\n\n- [x] 1. Greeting punctuation\n- [x] 2. Merge target\n"
+  );
+  t.write("blueprint/history/features/02-merge-target.md", MERGE_FEATURE_ARCHIVE);
+  t.git("add", "-A");
+  t.git("commit", "-m", "feat: add merge target");
+  const mergeTarget = t.git("rev-parse", "HEAD");
+  const mergeHeadBefore = t.git("rev-parse", "HEAD");
+  const mergeParents = t.git("show", "-s", "--format=%P", mergeTarget).split(" ").filter(Boolean);
+  const plannedMerge = t.agent(
+    "Run /rollback 2 because the merge target breaks a downstream consumer. Plan it and stop for review."
+  );
+  const mergeSpec = t.read("blueprint/context/current-feature.md") || "";
+
+  t.check("merge target fixture has two parents", mergeParents.length === 2);
+  t.check("merge target planning invocation succeeded", plannedMerge.status === 0);
+  t.check("merge target planning creates no rollback commit", t.git("rev-parse", "HEAD") === mergeHeadBefore);
+  t.check(
+    "merge target planning writes a rollback spec",
+    /^\*\*Type:\*\*\s*Rollback\s*$/im.test(mergeSpec)
+  );
+  t.check(
+    "merge target spec records the exact commit",
+    mergeSpec.includes(mergeTarget)
+  );
+
+  t.phase("implementation stops before reversing a merge target");
+  const implementation = t.agent(
+    "Run /implement for the current rollback spec. Stop if any rollback safeguard blocks the reverse patch; do not work around it."
+  );
+
+  t.check("merge target implementation invocation succeeded", implementation.status === 0);
+  t.check("merge target implementation creates no rollback commit", t.git("rev-parse", "HEAD") === mergeHeadBefore);
+  t.check(
+    "merge target implementation leaves the product code unchanged",
+    (t.read("src/merge-greeting.js") ?? "").includes("Hello from the merge target")
+  );
+  t.check(
+    "merge target implementation stages no reverse patch",
+    t.git("diff", "--cached", "--name-only").trim() === ""
+  );
+  t.check(
+    "implementation names the merge-parent blocker",
+    /merge target|merge commit|exactly one parent|single parent/i.test(implementation.resultText)
   );
 }
 

--- a/scripts/validate-blueprint.ts
+++ b/scripts/validate-blueprint.ts
@@ -11,6 +11,27 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const codexSkillsRoot = path.join(repoRoot, ".agents", "skills");
 const claudeSkillsRoot = path.join(repoRoot, ".claude", "skills");
+const currentFeatureStub = `# Current Feature
+
+> **Generated file.** Holds the one feature, fix, or rollback being built right now. Run
+> \`/feature <number-or-name>\` to spec a build-plan feature, or \`/fix "<bug>"\` for
+> an ad-hoc fix. Use \`/rollback <completed-feature>\` to plan a safe reversal.
+> Build one thing at a time; \`/complete\` archives it under
+> \`blueprint/history/\` and resets this file.
+
+_Nothing in progress. Run \`/feature\`, \`/fix\`, or \`/rollback\` to start._
+`;
+const findingsStub = `# Findings
+
+> **Generated file.** The findings ledger: review findings raised by \`/audit\`
+> against the work in progress, each with a durable ID, severity (P0-P3), and
+> status. \`/implement\` marks repaired findings \`fixed\`, a later \`/audit\` pass
+> moves them to \`closed\`, and \`/complete\` refuses to merge while any P0 or P1
+> finding is \`open\` or \`fixed\`, then archives resolved findings with the work
+> and resets this file.
+
+_No findings recorded. \`/audit\` appends findings here when it finds them._
+`;
 const requiredPaths = [
   "AGENTS.md",
   "CLAUDE.md",
@@ -95,6 +116,7 @@ async function main(): Promise<void> {
   await validateSkillMetadata(skills);
   await validateCommandInventories(skills);
   await validateVerificationContract();
+  await validateCanonicalStubs();
   await validateRepositoryPolish();
   const importCount = await validateClaudeImports();
   const referenceCount = await validateSkillReferences(codexFiles);
@@ -263,11 +285,41 @@ async function validateVerificationContract(): Promise<void> {
     ],
     [
       ".agents/skills/implement/SKILL.md",
-      ["declares a `Verify` command, run that exact", "fallback build and tests"]
+      [
+        "declares a `Verify` command, run that exact",
+        "fallback build and tests",
+        "both values match `^[0-9a-f]{40}$`",
+        "verify it has exactly one parent",
+        "Stop on a merge target",
+        "resolved parent exactly equals `Target parent`",
+        "Use only the resolved full SHA values"
+      ]
     ],
     [
       ".agents/skills/complete/SKILL.md",
-      ["exact `Verify` command from `AGENTS.md`", "fallback build and tests"]
+      [
+        "exact `Verify` command from `AGENTS.md`",
+        "fallback build and tests",
+        "Keep every unresolved entry in the ledger",
+        "A `fixed` entry is not resolved at any severity",
+        "must remain verbatim for a later `/audit` re-review",
+        "replace `blueprint/context/current-feature.md` with the canonical stub below"
+      ]
+    ],
+    [
+      ".agents/skills/rollback/SKILL.md",
+      [
+        "target commit and parent commit as full 40-character SHA values",
+        "name the merge target as an implementation blocker",
+        "`/implement` stops before applying a merge target"
+      ]
+    ],
+    [
+      ".agents/skills/rollback/reference/rollback-spec-template.md",
+      [
+        "**Target commit:** `<full 40-character commit SHA>`",
+        "**Target parent:** `<full 40-character parent SHA>`"
+      ]
     ],
     [
       ".agents/skills/doctor/SKILL.md",
@@ -316,6 +368,42 @@ async function validateVerificationContract(): Promise<void> {
       }
     }
   }
+}
+
+async function validateCanonicalStubs(): Promise<void> {
+  const [currentFeature, findings, completeSkill] = await Promise.all([
+    fs.readFile(path.join(repoRoot, "blueprint/context/current-feature.md"), "utf8"),
+    fs.readFile(path.join(repoRoot, "blueprint/context/findings.md"), "utf8"),
+    fs.readFile(path.join(codexSkillsRoot, "complete", "SKILL.md"), "utf8")
+  ]);
+
+  if (normalizeEol(currentFeature) !== currentFeatureStub) {
+    throw new Error("Current feature stub must exactly match the canonical content and final newline");
+  }
+
+  if (normalizeEol(findings) !== findingsStub) {
+    throw new Error("Findings stub must exactly match the canonical content and final newline");
+  }
+
+  if (!normalizeEol(completeSkill).includes(indentMarkdownBlock(currentFeatureStub))) {
+    throw new Error("Complete skill must embed the canonical current feature stub");
+  }
+
+  if (!normalizeEol(completeSkill).includes(indentMarkdownBlock(findingsStub))) {
+    throw new Error("Complete skill must embed the canonical findings stub");
+  }
+}
+
+// Markdown is not pinned in .gitattributes, so Windows checkouts see CRLF here.
+function normalizeEol(content: string): string {
+  return content.replaceAll("\r\n", "\n");
+}
+
+function indentMarkdownBlock(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => (line ? `    ${line}` : ""))
+    .join("\n");
 }
 
 async function validateClaudeImports(): Promise<number> {


### PR DESCRIPTION
## Summary

Two safety-critical paths depended on prose that the static contract never enforced.

1. `/rollback` recorded a target commit and parent as free-form SHAs, and `/implement` then reverse-applied a product diff from those values. An abbreviated, uppercase, or stale SHA, or a merge commit with more than one parent, could reach the reverse-apply step.
2. `/complete` reset `blueprint/context/current-feature.md` and pruned the findings ledger. Nothing pinned the canonical stub text or prevented dropping unresolved entries, so a paraphrased stub or a silently discarded `fixed` finding both passed validation.

Changes:

1. `rollback`: require the target commit and its parent as full 40-character SHA values, and treat a merge target as an implementation blocker rather than selecting a mainline. The spec template is updated to match.
2. `implement`: add an explicit six-step precondition sequence before any reverse patch. Validate both SHAs against `^[0-9a-f]{40}$`, require exactly one parent, confirm the resolved commit and parent equal the recorded values, confirm the target is an ancestor of `HEAD`, require a clean tree apart from the approved spec, and use only resolved full SHAs when applying.
3. `complete`: archive only `closed`, `accepted`, and `invalid` findings. A `fixed` entry is never archived or removed at any severity, so it stays available for a later `/audit` re-review. The canonical `current-feature.md` and `findings.md` stubs are embedded verbatim and must match exactly rather than be paraphrased.
4. `scripts/validate-blueprint.ts`: add `validateCanonicalStubs`, asserting that both stub files match the canonical content including the final newline, and that `complete/SKILL.md` embeds both stubs. Extend the verification contract with the new rollback and complete phrases so the guidance cannot silently regress.
5. `scripts/e2e/scenarios/ledger-gate.ts` and `scripts/e2e/scenarios/rollback-plan.ts`: assert the new behavior end to end, including that a `fixed` finding survives completion and that malformed or merge targets are refused.

Both adapter trees are updated identically, so `.agents/` and `.claude/` stay in sync.

### Cross-platform note

`validateCanonicalStubs` compares multi-line content exactly. Markdown is not pinned to LF in `.gitattributes`, so on a Windows checkout with `core.autocrlf=true` the skill files arrive as CRLF and every stub assertion fails locally while still passing on Linux CI. A small `normalizeEol` helper collapses `\r\n` before comparison, so the contract holds on both platforms. Content strictness and the trailing-newline requirement are unchanged.

## Validation

```text
npm run typecheck        pass
npm run check:static     pass, 22 skills, 29 adapter files, 5 Claude imports, 4 skill references
npm run test:sandbox     pass, 9 passed, 1 skipped
npm run test:routing     pass
```

`npm run check` runs five checks and stops at the first failure. On this branch alone it stops at check four, "Installer unit tests", because of a pre-existing Windows path-separator bug this branch does not touch, fixed separately in aiblueprinthq/ai-blueprint#10. With this branch stacked on #10 and #8, the complete gate passes locally:

```text
[check] Static Blueprint contract        pass, 22 skills, 29 adapter files, 5 Claude imports, 4 skill references
[check] Skill routing evaluations        pass
[check] Sandbox runner unit tests        pass
[check] Installer unit tests             pass
[check] Packed installer smoke tests     pass
AI Blueprint validation passed.
```

`npm run test:e2e` was not run. It drives a live agent and spends real tokens, and CONTRIBUTING.md documents it as an explicit opt-in that never runs in CI. The two changed scenarios are covered by `npm run typecheck`.

Environment: Windows 11, Node v24.19.0, npm 12.0.2.


## Checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Shared skill changes are synchronized across `.agents/skills/` and `.claude/skills/`.
- [x] User-facing behavior is reflected in the root and package documentation where needed. No command was added or removed, so the `AGENTS.md` inventory and README command table are unchanged; the shipped rollback spec template is updated in both adapter trees.
- [x] `npm run check` passes locally, when stacked with #10 which fixes the unrelated check-four failure. Output above.
- [x] No secrets, credentials, private code, or personal data are included.
- [x] Package version and release notes are updated when the change is intended for publication. Added a `CHANGELOG.md` entry under `Unreleased`. I did not bump the package version, since that appears to be a maintainer release step.
