### PR TITLE
fix: report the config path with a stable separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ published `create-ai-blueprint` package.
 
 ## Unreleased
 
+### Fixed
+
+- Reported the Blueprint config path as `blueprint/config.json` in warnings and
+  status output on every platform, instead of leaking the Windows separator.
+
 ## [0.14.0] - 2026-08-25
 
 ### Added

--- a/packages/create-ai-blueprint/lib/project-config.ts
+++ b/packages/create-ai-blueprint/lib/project-config.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const PROJECT_CONFIG_PATH = path.join("blueprint", "config.json");
+// Stable repo-relative identifier for warnings and status output. path.join
+// normalizes the separator for filesystem reads, so this must not be built with
+// path.join or Windows would surface "blueprint\config.json" to users.
+const PROJECT_CONFIG_PATH = "blueprint/config.json";
 const PROJECT_CONFIG_SCHEMA_VERSION = 1 as const;
 
 type StepReviewPolicy = "every" | "feature";


### PR DESCRIPTION
## Summary

`readProjectConfig` builds its repo-relative identifier with `path.join`, so on Windows the constant resolves to `blueprint\config.json`. That value is not internal: it is returned as `ProjectConfigResult.path`, surfaced as `configuration.path` in status output, and interpolated into two user-facing warnings.

```text
Invalid Blueprint config JSON: blueprint\config.json
Unsupported or invalid Blueprint config: blueprint\config.json. ...
```

Every other reference to this file in the repository, including the README, `AGENTS.md`, and the `status` reason string `Repair blueprint/config.json before running a mutating workflow.`, uses the forward-slash form. The Windows output contradicts the documentation and the tool's own messages.

It also breaks `npm test` on Windows. `packages/create-ai-blueprint/test/project-config.test.ts` asserts the forward-slash message, so the suite fails for any Windows contributor before they have changed anything.

The fix declares the constant as a plain POSIX string. Filesystem behavior is unchanged, because the only consumer is `path.join(projectRoot, PROJECT_CONFIG_PATH)`, and `path.join` normalizes a forward slash to the platform separator:

```text
path.win32.join('C:\\a\\b', 'blueprint/config.json') -> 'C:\\a\\b\\blueprint\\config.json'
path.posix.join('/a/b', 'blueprint/config.json')     -> '/a/b/blueprint/config.json'
```

This matches the convention already used in `lib/update.ts`, where `MANIFEST_PATH` is a POSIX template string precisely because it appears in error messages and installer output.

Scope note: seven sibling constants in `lib/` are still built with `path.join`, in `status.ts`, `project-root.ts`, `history.ts`, `findings.ts`, `current-work.ts`, and `build-plan.ts`. I left them alone because none of them currently reach user-facing output; they are used only as filesystem path segments. `PROJECT_CONFIG_PATH` is the one that is displayed. Happy to follow up separately if you would rather normalize all of them at once.

## Validation

```text
npm run typecheck        pass
npm test                 pass, 61 passed, 1 skipped, 0 failed
npm run check:static     pass, 22 skills, 29 adapter files, 5 Claude imports, 4 skill references
```

Before this change, `npm test` failed on Windows with:

```text
actual:   [ { code: 'invalid_config', message: 'Invalid Blueprint config JSON: blueprint\config.json' } ]
expected: [ { code: 'invalid_config', message: 'Invalid Blueprint config JSON: blueprint/config.json' } ]
```

`npm run check` runs five checks and stops at the first failure. On this branch alone it now clears checks one through four and fails on the fifth, "Packed installer smoke tests", from an unrelated Windows quoting bug fixed in aiblueprinthq/ai-blueprint#8. With this branch stacked on #8 and #9, the complete gate passes locally:

```text
[check] Static Blueprint contract        pass, 22 skills, 29 adapter files, 5 Claude imports, 4 skill references
[check] Skill routing evaluations        pass
[check] Sandbox runner unit tests        pass
[check] Installer unit tests             pass
[check] Packed installer smoke tests     pass
AI Blueprint validation passed.
```

Environment: Windows 11, Node v24.19.0, npm 12.0.2.


## Checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Shared skill changes are synchronized across `.agents/skills/` and `.claude/skills/`. Not applicable, no skill files changed.
- [x] User-facing behavior is reflected in the root and package documentation where needed. The documentation already specifies `blueprint/config.json`; this makes the runtime output agree with it.
- [x] `npm run check` passes locally, when stacked with #8 which fixes the unrelated check-five failure. Output above.
- [x] No secrets, credentials, private code, or personal data are included.
- [x] Package version and release notes are updated when the change is intended for publication. Added a `CHANGELOG.md` entry under `Unreleased`. I did not bump the package version, since that appears to be a maintainer release step.
