### PR TITLE
fix: resolve installer package root and add local checkout linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ published `create-ai-blueprint` package.
 
 ## Unreleased
 
+### Added
+
+- Added `npm run link:local` and `npm run unlink:local` for building, preparing,
+  and globally linking the installer from a local checkout, so `create-ai-blueprint`
+  and `blueprint` run from local files with no network access.
+
+### Fixed
+
+- Fixed installer package root resolution so a source checkout finds its own
+  `template/` directory. The documented local testing path failed because the
+  installer looked one directory above the package.
+
 ## [0.14.0] - 2026-08-25
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,41 @@ framework abstractions do not belong in this repository.
 | `npm run sandbox` | Scaffold a minimal app, run the local packed Blueprint through its real prompts, verify it, and start its server. |
 | `npm run sandbox:clear` | List every saved sandbox run, ask for confirmation, then delete those runs. |
 | `npm run sandbox:demo` | Run the interactive sandbox with example project and build plans ready for workflow testing. |
+| `npm run link:local` | Build this checkout, prepare its template, and link `create-ai-blueprint` and `blueprint` globally so they run from local files. |
+| `npm run unlink:local` | Remove the global link created by `npm run link:local`. |
 | `E2E_ACCEPT_RISK=1 npm run test:e2e` | Run all live-agent behavior scenarios in scratch repositories. |
 
 Run `npm run check` before opening or merging a pull request. The package smoke
 test builds the installer template, packs it into a temporary directory, installs
 that artifact locally, verifies every supported adapter mode, and removes its temporary
 files.
+
+## Running the installer from a local checkout
+
+`npx create-ai-blueprint` always fetches the published package. To install from
+your own checkout instead, including a fork with local modifications, link it
+once:
+
+```bash
+npm run link:local
+```
+
+That builds the installer, prepares its template, and links the `create-ai-blueprint`
+and `blueprint` commands globally. They then run entirely from local files, with no
+network access:
+
+```bash
+create-ai-blueprint --target ../my-app
+blueprint status
+```
+
+Re-run `npm run link:local` after editing the source. The linked commands run the
+compiled `dist/` output and a copied `template/`, not the source files directly, so
+edits are not picked up until both are rebuilt.
+
+`npm run unlink:local` runs `npm rm --global create-ai-blueprint`, which removes any
+global copy of the package, whether it was linked from a checkout or installed from
+the registry.
 
 ## Inspectable scaffold sandbox
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "check": "npm run typecheck && tsx scripts/check-blueprint.ts",
     "check:static": "tsx scripts/validate-blueprint.ts",
+    "link:local": "tsx scripts/link-local.ts",
+    "unlink:local": "tsx scripts/link-local.ts --undo",
     "test": "npm --prefix packages/create-ai-blueprint test",
     "test:routing": "tsx --test scripts/evals/routing.test.ts && tsx scripts/evals/routing.ts --min-rank1 90",
     "test:sandbox": "tsx --test scripts/scaffold-sandbox.test.ts scripts/clear-sandbox.test.ts",

--- a/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
+++ b/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
@@ -24,7 +24,7 @@ import {
 import type { Adapter, PreparedUpdate, UpdateResult } from "../lib/update.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const packageRoot = path.resolve(__dirname, "..", "..");
+const packageRoot = findPackageRoot(__dirname);
 const templateRoot = path.join(packageRoot, "template");
 const ADAPTER_PROMPT = "Select AI tool adapters";
 const ALL_ADAPTERS = adapterListFromMode("all");
@@ -135,9 +135,7 @@ async function runCli(
   }
 
   if (!fsSync.existsSync(templateRoot)) {
-    throw new Error(
-      "Installer template is missing. Run `npm run prepare-template` before local testing."
-    );
+    throw new Error(formatMissingTemplateMessage(templateRoot));
   }
 
   const version = readPackageVersion();
@@ -900,6 +898,36 @@ Install or update Blueprint with:
   npx create-ai-blueprint@latest update`);
 }
 
+// Correct for both layouts: dist/bin/ when published, bin/ in a source checkout.
+// Relies on nothing between the entry point and the package root carrying its own
+// package.json, so a build that emits dist/package.json would break this.
+function findPackageRoot(startDir: string): string {
+  let current = startDir;
+
+  for (;;) {
+    if (fsSync.existsSync(path.join(current, "package.json"))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+
+    if (parent === current) {
+      throw new Error(
+        `Could not locate the installer package root above ${startDir}.`
+      );
+    }
+
+    current = parent;
+  }
+}
+
+function formatMissingTemplateMessage(templateRoot: string): string {
+  return `Installer template is missing.
+Looked in: ${templateRoot}
+This looks like a source checkout, where the template is a build artifact.
+Run \`npm run link:local\` from the repository root, or \`npm run prepare-template\` inside the installer package.`;
+}
+
 function readPackageVersion(): string {
   const packageJson = fsSync.readFileSync(
     path.join(packageRoot, "package.json"),
@@ -930,6 +958,8 @@ if (
 
 export {
   ADAPTER_PROMPT,
+  findPackageRoot,
+  formatMissingTemplateMessage,
   getGlobalCliInstallCommand,
   getGlobalCliPrompt,
   getTemplateEntries,

--- a/packages/create-ai-blueprint/test/update.test.ts
+++ b/packages/create-ai-blueprint/test/update.test.ts
@@ -7,6 +7,8 @@ import test, { type TestContext } from "node:test";
 
 import {
   ADAPTER_PROMPT,
+  findPackageRoot,
+  formatMissingTemplateMessage,
   getTemplateEntries,
   getGlobalCliInstallCommand,
   getGlobalCliPrompt,
@@ -808,6 +810,42 @@ test("update refuses to write through a symbolic-link directory", async (t) => {
     prepareUpdate({ targetDir, templateRoot, version: "1.1.0" }),
     /Refusing to write through symbolic-link directory/
   );
+});
+
+test("findPackageRoot walks up to the nearest package.json", async (t: TestContext) => {
+  const workspace = await createWorkspace(t);
+  const nested = path.join(workspace, "pkg", "dist", "bin");
+  await fs.mkdir(nested, { recursive: true });
+  await writeFiles(workspace, {
+    "package.json": '{ "name": "outer-workspace" }\n',
+    "pkg/package.json": '{ "name": "nested-package" }\n'
+  });
+
+  const packageRoot = path.join(workspace, "pkg");
+  assert.equal(findPackageRoot(nested), packageRoot);
+  assert.equal(findPackageRoot(path.join(packageRoot, "bin")), packageRoot);
+  assert.equal(findPackageRoot(packageRoot), packageRoot);
+});
+
+test("findPackageRoot resolves this checkout to the installer package", () => {
+  const packageRoot = path.resolve(import.meta.dirname, "..");
+
+  assert.equal(findPackageRoot(path.join(packageRoot, "bin")), packageRoot);
+  assert.equal(
+    findPackageRoot(path.join(packageRoot, "dist", "bin")),
+    packageRoot
+  );
+  assert.notEqual(findPackageRoot(path.join(packageRoot, "bin")), path.dirname(packageRoot));
+});
+
+test("formatMissingTemplateMessage names the directory it searched", () => {
+  const searched = path.join("some", "where", "template");
+  const message = formatMissingTemplateMessage(searched);
+
+  assert.match(message, /Installer template is missing/);
+  assert.ok(message.includes(searched));
+  assert.match(message, /npm run link:local/);
+  assert.match(message, /npm run prepare-template/);
 });
 
 async function createWorkspace(t: TestContext): Promise<string> {

--- a/scripts/link-local.ts
+++ b/scripts/link-local.ts
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const packageRoot = path.join(repoRoot, "packages", "create-ai-blueprint");
+
+interface NpmInvocation {
+  command: string;
+  prefix: string[];
+}
+
+function npmInvocation(): NpmInvocation {
+  const npmExecPath = process.env.npm_execpath;
+
+  if (npmExecPath) {
+    return { command: process.execPath, prefix: [npmExecPath] };
+  }
+
+  return {
+    command: process.platform === "win32" ? "npm.cmd" : "npm",
+    prefix: []
+  };
+}
+
+function runNpm(args: readonly string[]): void {
+  const { command, prefix } = npmInvocation();
+  const result = spawnSync(command, [...prefix, ...args], {
+    cwd: packageRoot,
+    stdio: "inherit",
+    // Windows refuses to spawn npm.cmd without a shell, so only the fallback
+    // invocation needs one. The npm_execpath form runs through node directly.
+    shell: prefix.length === 0 && process.platform === "win32"
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`npm ${args.join(" ")} failed with status ${result.status}.`);
+  }
+}
+
+function readPackageName(): string {
+  const raw = fs.readFileSync(path.join(packageRoot, "package.json"), "utf8");
+  const parsed: unknown = JSON.parse(raw);
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as { name?: unknown }).name !== "string"
+  ) {
+    throw new Error("Installer package.json has no valid name.");
+  }
+
+  return (parsed as { name: string }).name;
+}
+
+function main(): void {
+  const packageName = readPackageName();
+
+  if (process.argv.slice(2).includes("--undo")) {
+    runNpm(["rm", "--global", packageName]);
+    console.log(
+      `\nRan \`npm rm --global ${packageName}\`. Any global copy of that package, linked or installed, is gone.`
+    );
+    return;
+  }
+
+  runNpm(["run", "build"]);
+  runNpm(["run", "prepare-template"]);
+  runNpm(["link"]);
+
+  console.log(`
+Linked ${packageName} from this checkout.
+
+These commands now run from your local files, with no network access:
+  create-ai-blueprint --help
+  create-ai-blueprint --target ./my-app
+  blueprint status
+
+Re-run \`npm run link:local\` after editing the source. The linked commands run
+the compiled dist/ output and a copied template/, not the source files directly.
+
+Undo with:
+  npm run unlink:local`);
+}
+
+try {
+  main();
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

The installer cannot be run from a source checkout, and its own error message sends you down a path that does not work. Running it from a checkout says:

```text
Installer template is missing. Run `npm run prepare-template` before local testing.
```

Running `npm run prepare-template` succeeds, and then the identical error appears again.

The cause is package root resolution. `packageRoot` was `path.resolve(__dirname, "..", "..")`, correct for the published layout (`dist/bin/` up two levels to the package root) but wrong for a checkout, where `bin/` up two levels lands on `packages/`. The installer looked for `packages/template` while the generator writes `packages/create-ai-blueprint/template`, and `readPackageVersion` failed with `ENOENT ... packages\package.json`.

Two changes:

1. **`findPackageRoot`** walks up from `__dirname` to the nearest directory containing a `package.json`, which is correct in both layouts. It deliberately does not assert a package name, so a fork that renames the package still works. The missing-template error now reports the exact directory it searched.

2. **`npm run link:local`** builds the installer, prepares its template, and runs `npm link`, after which `create-ai-blueprint` and `blueprint` run entirely from local files with no network access. `npm run unlink:local` undoes it.

This overlaps only partially with `npm run sandbox` and `npm run test:package`. Those pack the tarball and install it into a scratch directory under `.sandbox/`, which is the right shape for a one-shot acceptance run. Linking installs the commands globally, so they can be pointed at real projects outside this repository, repeatedly, without a pack step each time. It is also what lets a fork maintainer run their own version of the blueprint without publishing it.

Implementation notes:

- The script spawns npm through `process.env.npm_execpath`, matching the existing convention in `bin/create-ai-blueprint.ts`, because `spawnSync("npm.cmd", ...)` without a shell fails with `EINVAL` on current Node on Windows.
- A `prepare` lifecycle script would have been tidier, but npm 12 blocks lifecycle scripts by default (`npm warn install-scripts ... not covered by allowScripts`), so `dist/` was never built and no shims were produced. `npm link` also does not run `prepack`, so the build and template steps have to be explicit.
- `findPackageRoot` depends on nothing between the entry point and the package root carrying its own `package.json`. That holds today, since `tsc` emits none into `dist/`, but it is an assumption rather than a guarantee, so it is documented at the function and asserted by a test that would fail if the resolution ever landed on `packages/` again.
- There is deliberately no fallback to the repository root, even though the root files are currently byte-identical to the generated template (verified: 71 files, 0 differences). `scripts/prepare-template.ts` stays the single build-time boundary, so root blueprint files remain free to gain project-specific content later without silently changing what a local install produces.

The failure mode is now accurate and actionable:

```text
Installer template is missing.
Looked in: D:\...\packages\create-ai-blueprint\template
This looks like a source checkout, where the template is a build artifact.
Run `npm run link:local` from the repository root, or `npm run prepare-template` inside the installer package.
```

That path is the real one. Before this change it pointed at `packages\template`, which nothing ever creates.

## Validation

```text
npm run typecheck       pass
npm run check:static    pass (22 skills, 29 adapter files, 5 Claude imports, 4 skill references)
npm test                65 tests, 63 pass, 1 fail
```

The single failure is `project-config.test.ts`, which asserts `blueprint/config.json` against the `blueprint\config.json` that `path.join` produces on Windows. It is pre-existing and unrelated: stashing this branch and running that file alone on `main` reproduces the same 1 of 6 failure. #10 already fixes it.

`npm run check` passes in CI on Node 22 and 24. It does not pass standalone on Windows, for an unrelated reason: its packed smoke-test stage fails on an unquoted path, which is what #8 fixes. Stacked locally with #8 and #10, the full gate passes on Windows too, covering the static contract, sandbox tests, routing evaluations, scaffold tests, 64 installer unit tests, and the packed installer across default, individual, combined, all, and legacy adapter modes. `npm run test:e2e` was not run.

Three new unit tests cover `findPackageRoot` picking the nearest `package.json` when an outer one also exists, `findPackageRoot` resolving this checkout to the installer package rather than `packages/`, and `formatMissingTemplateMessage`. The second is the regression guard for the reported bug. The existing package smoke test could not have caught it, because it only exercises the published tarball layout, where the old resolution was already correct.

End to end, against an isolated global npm prefix so real global state was never touched:

```text
npm run link:local     built, prepared template, linked, 3 shims created
create-ai-blueprint    installed into a scratch project from the linked checkout
npm run unlink:local   junction and all shims removed, verified absent
```

Provenance was proved rather than assumed. A marker string was added to the local `template/AGENTS.md` and it appeared in the installed project's `AGENTS.md`, confirming the local checkout was the source and not a downloaded package.

## Checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Shared skill changes are synchronized across `.agents/skills/` and `.claude/skills/`. (No skill files changed.)
- [x] User-facing behavior is reflected in the root and package documentation where needed.
- [x] `npm run check` passes locally. (Green in CI on Node 22 and 24. Standalone on Windows it needs #8, which fixes an unrelated unquoted path in the packed smoke test; stacked with #8 and #10 the full gate passes there too.)
- [x] No secrets, credentials, private code, or personal data are included.
- [x] Package version and release notes are updated when the change is intended for publication. (`CHANGELOG.md` under Unreleased; no version bump, left to your release process.)