### PR TITLE
feat: enforce proportional engineering across Blueprint workflows

### DIFF
--- a/.agents/skills/adopt/SKILL.md
+++ b/.agents/skills/adopt/SKILL.md
@@ -83,6 +83,9 @@ The code reveals *what* and *how*, never *why* or *what next*. Ask the user a sh
 set of questions (aim for three to five, not an interrogation) to fill the gaps:
 
 - What is this project for, and who uses it? (the problem and the users)
+- Are any material reachability or deployment constraints not already evident
+  from the code? Ask only when an answer would materially change the roadmap or
+  architecture; do not turn this into a scale or security questionnaire.
 - Is the stack and structure you found intentional, or are there parts they'd call
   legacy / want to change?
 - What do you want to build next? (the unchecked items in the build plan)
@@ -98,9 +101,12 @@ inference you're unsure of with a clear `> TODO (confirm)` so the user can corre
 it rather than inherit a wrong guess.
 
 - **`blueprint/project-plan.md`** - the what & why, following the existing
-  worksheet structure (problem, users, features, data, tech, monetization, UI/UX).
+  worksheet structure (problem, users, features, data, tech, monetization, UI/UX,
+  deployment, and optional usage model).
   The "features" and "tech" sections describe what *already exists*; the rest comes
-  from the interview.
+  from the interview. Record observed auth, ownership, reachability, tenancy, and
+  deployment facts before asking; leave unknown usage fields blank rather than
+  inventing requirements.
 - **`blueprint/build-plan.md`** - the ordered feature list as a checklist. **Mark
   shipped features `- [x]`** (this is the brownfield difference: the build plan
   reflects reality, so most of an existing app starts checked) and the roadmap
@@ -161,7 +167,8 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  and coding conventions, but remove or avoid Blueprint workflow explanations,
+  coding conventions, and the Proportional engineering contract, but remove or
+  avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the
@@ -199,6 +206,8 @@ the normal loop.
 - **Reflect reality, don't prescribe.** `coding-standards.md` must match the code
   that exists. A project using Zustand and REST routes should not be handed
   standards about Server Actions and Prisma just because that's the default.
+- Preserve the Proportional engineering contract in `AGENTS.md`; untuned
+  stack-specific template defaults are not established project requirements.
 - **Never invent intent.** Ask for the why and the roadmap; mark anything inferred
   with `> TODO (confirm)`. Silent guesses about purpose are the main failure mode.
 - **Don't clobber owned work.** If the plans already have real content, confirm

--- a/.agents/skills/adopt/SKILL.md
+++ b/.agents/skills/adopt/SKILL.md
@@ -83,9 +83,6 @@ The code reveals *what* and *how*, never *why* or *what next*. Ask the user a sh
 set of questions (aim for three to five, not an interrogation) to fill the gaps:
 
 - What is this project for, and who uses it? (the problem and the users)
-- Are any material reachability or deployment constraints not already evident
-  from the code? Ask only when an answer would materially change the roadmap or
-  architecture; do not turn this into a scale or security questionnaire.
 - Is the stack and structure you found intentional, or are there parts they'd call
   legacy / want to change?
 - What do you want to build next? (the unchecked items in the build plan)
@@ -101,12 +98,9 @@ inference you're unsure of with a clear `> TODO (confirm)` so the user can corre
 it rather than inherit a wrong guess.
 
 - **`blueprint/project-plan.md`** - the what & why, following the existing
-  worksheet structure (problem, users, features, data, tech, monetization, UI/UX,
-  deployment, and optional usage model).
+  worksheet structure (problem, users, features, data, tech, monetization, UI/UX).
   The "features" and "tech" sections describe what *already exists*; the rest comes
-  from the interview. Record observed auth, ownership, reachability, tenancy, and
-  deployment facts before asking; leave unknown usage fields blank rather than
-  inventing requirements.
+  from the interview.
 - **`blueprint/build-plan.md`** - the ordered feature list as a checklist. **Mark
   shipped features `- [x]`** (this is the brownfield difference: the build plan
   reflects reality, so most of an existing app starts checked) and the roadmap
@@ -167,8 +161,7 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  coding conventions, and the Proportional engineering contract, but remove or
-  avoid Blueprint workflow explanations,
+  and coding conventions, but remove or avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the
@@ -206,8 +199,8 @@ the normal loop.
 - **Reflect reality, don't prescribe.** `coding-standards.md` must match the code
   that exists. A project using Zustand and REST routes should not be handed
   standards about Server Actions and Prisma just because that's the default.
-- Preserve the Proportional engineering contract in `AGENTS.md`; untuned
-  stack-specific template defaults are not established project requirements.
+- Follow and preserve the proportional-engineering contract in `AGENTS.md`;
+  record only established usage or trust constraints and leave unknowns blank.
 - **Never invent intent.** Ask for the why and the roadmap; mark anything inferred
   with `> TODO (confirm)`. Silent guesses about purpose are the main failure mode.
 - **Don't clobber owned work.** If the plans already have real content, confirm

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -296,7 +296,10 @@ expectations. Apply only the selected lens or lenses:
 
 - **Quality:** duplicated logic, dead or unused code, unreachable paths,
   oversized modules, abstractions that do not pay for themselves, risky missing
-  abstractions, inconsistent patterns, and drift from the standards or spec.
+  abstractions, speculative dependencies, services, configuration surfaces,
+  compatibility layers or security machinery, inconsistent patterns, and drift
+  from the standards or spec. Untuned stack-specific template defaults are not
+  established requirements.
 - **Security:** missing authentication or authorization, client-controlled
   ownership, injection, unsafe parsing or deserialization, sensitive-data
   exposure, secret handling, insecure defaults, and trust-boundary mistakes.
@@ -314,6 +317,13 @@ expectations. Apply only the selected lens or lenses:
 
 Do not nitpick harmless style differences unless they signal drift from the local
 patterns. Prefer a short list of real findings over a broad list of guesses.
+
+For a proportionality finding, state in **Suggested fix** what can be deleted,
+which existing, standard-library, native-platform, or installed mechanism
+replaces it, and which current requirement would be lost. Use `None` when no
+current requirement would be lost. If the suggested fix removes or changes
+shipped behavior, require an explicit user decision and never describe it as an
+automatic repair.
 
 Do not broaden a focused pass because another category might be interesting.
 Do not report or call out non-critical concerns from omitted lenses, even as
@@ -413,6 +423,9 @@ Use P0 or P1 only when a concrete code path, violated contract or security
 boundary, failing command or test, or reproducible behavior confirms the risk. If
 the evidence is incomplete, list it under `Unverified risks` with the missing
 validation instead of presenting it as a confirmed high-severity finding.
+An otherwise pure proportionality finding is P2 or P3. Raise it to P0 or P1 only
+when the unnecessary machinery causes a concrete reachable defect or violates an
+established security or data-integrity boundary.
 
 If there are no findings, say that clearly for the selected lens and name any
 remaining risk or missing signal, such as "no test command declared" or

--- a/.agents/skills/autopilot/SKILL.md
+++ b/.agents/skills/autopilot/SKILL.md
@@ -117,17 +117,13 @@ If there is no active spec:
    - undefined contracts
    - missing design reference
    - scope creep
-   - speculative abstractions, dependencies, services, configuration surfaces,
-     compatibility layers, or security mechanisms
    - vague done-whens
    - missing testing plan when `AGENTS.md` declares a test command
 4. Apply the spec fixes.
 
 Autopilot may continue past this spec gate because the user explicitly invoked
 Autopilot. Still report what the critique changed in the final packet.
-Never stop for a reversible internal detail with no user-visible, security,
-persisted-data, interoperability, or cost consequence; choose the smaller
-repository-native option.
+Follow the proportional-engineering contract in `AGENTS.md` throughout this run.
 
 ## Step 3 - create or reuse the branch
 
@@ -147,10 +143,6 @@ Do not pause for user approval after each passing step, regardless of the
 configured `workflow.stepReview` value. The review happens at the final packet
 unless a hard stop is hit.
 
-Add an abstraction, dependency, service, configuration surface, compatibility
-layer, or security mechanism only when the approved spec or an established
-repository requirement needs it now.
-
 For every step:
 
 1. Implement only that step.
@@ -169,8 +161,6 @@ For every step:
 4. Self-review the diff for the step:
    - does it match the spec?
    - did it add scope?
-   - does every new layer trace to a current requirement, and can existing code,
-     the standard library, the platform, or an installed dependency replace it?
    - is the error path handled?
    - did it follow `coding-standards.md`?
    - are tests present for new in-scope logic when the test gate is on?

--- a/.agents/skills/autopilot/SKILL.md
+++ b/.agents/skills/autopilot/SKILL.md
@@ -117,12 +117,17 @@ If there is no active spec:
    - undefined contracts
    - missing design reference
    - scope creep
+   - speculative abstractions, dependencies, services, configuration surfaces,
+     compatibility layers, or security mechanisms
    - vague done-whens
    - missing testing plan when `AGENTS.md` declares a test command
 4. Apply the spec fixes.
 
 Autopilot may continue past this spec gate because the user explicitly invoked
 Autopilot. Still report what the critique changed in the final packet.
+Never stop for a reversible internal detail with no user-visible, security,
+persisted-data, interoperability, or cost consequence; choose the smaller
+repository-native option.
 
 ## Step 3 - create or reuse the branch
 
@@ -142,6 +147,10 @@ Do not pause for user approval after each passing step, regardless of the
 configured `workflow.stepReview` value. The review happens at the final packet
 unless a hard stop is hit.
 
+Add an abstraction, dependency, service, configuration surface, compatibility
+layer, or security mechanism only when the approved spec or an established
+repository requirement needs it now.
+
 For every step:
 
 1. Implement only that step.
@@ -160,6 +169,8 @@ For every step:
 4. Self-review the diff for the step:
    - does it match the spec?
    - did it add scope?
+   - does every new layer trace to a current requirement, and can existing code,
+     the standard library, the platform, or an installed dependency replace it?
    - is the error path handled?
    - did it follow `coding-standards.md`?
    - are tests present for new in-scope logic when the test gate is on?
@@ -258,8 +269,9 @@ For every finding:
    local project patterns. An audit finding is evidence to investigate, not an
    automatic instruction to edit.
 2. Repair confirmed P0 and P1 findings when the fix stays inside the approved
-   feature scope and does not require a product or architecture decision. Set
-   the repaired finding to `fixed` in the ledger, never `closed`.
+   feature scope, does not require a product or architecture decision, and does
+   not remove or change shipped behavior. Set the repaired finding to `fixed` in
+   the ledger, never `closed`.
 3. Report P2 and P3 findings in the final packet. Fix them only when the change
    is small, directly caused by the current feature, and clearly required by the
    project standards.

--- a/.agents/skills/continuous/SKILL.md
+++ b/.agents/skills/continuous/SKILL.md
@@ -137,6 +137,9 @@ plans.
 
 Do not invent an unanswered product, data, architecture, auth, billing, or visual
 decision. Stop with the exact decision needed.
+Never stop for a reversible internal detail with no user-visible, security,
+persisted-data, interoperability, or cost consequence; choose the smaller
+repository-native option.
 
 ### 2.2 Create or resume the feature branch
 
@@ -157,6 +160,10 @@ Build the spec in order, one small diff at a time. Continuous Mode does not paus
 for `workflow.stepReview`; its explicit invocation replaces those review
 prompts with self-review plus the final packet.
 
+Add an abstraction, dependency, service, configuration surface, compatibility
+layer, or security mechanism only when the approved spec or an established
+repository requirement needs it now.
+
 For each step:
 
 1. Implement only that step.
@@ -164,8 +171,10 @@ For each step:
 3. Run the exact documented `Verify` command when present. Otherwise run the
    documented build and existing relevant tests.
 4. Enforce `verification.logicTests` and `verification.uiEvidence`.
-5. Self-review scope, error paths, security boundaries, project conventions, and
-   tests.
+5. Self-review scope, error paths, security boundaries, project conventions,
+   tests, and whether every new layer traces to a current requirement instead of
+   duplicating existing code, the standard library, the platform, or an installed
+   dependency.
 6. Repair failures within scope, rerun affected evidence, and check off the step
    only when it passes.
 7. When `workflow.checkpointCommits` is `enabled`, create a conventional local
@@ -209,9 +218,10 @@ blockers always apply even when audit is manual.
 ### 2.5 Repair and re-review findings
 
 Validate audit findings before editing. Repair confirmed P0 and P1 findings only
-when the repair stays within feature scope and needs no user decision. Use
-`continuous.maxRepairAttempts` as the maximum attempts for the same failing
-check or finding; `0` disables automatic repair.
+when the repair stays within feature scope, needs no user decision, and does not
+remove or change shipped behavior. Use `continuous.maxRepairAttempts` as the
+maximum attempts for the same failing check or finding; `0` disables automatic
+repair.
 
 After a repair, rerun affected verification and acceptance evidence, then
 re-audit the repaired area. Move `fixed` to `closed` only when the audit

--- a/.agents/skills/continuous/SKILL.md
+++ b/.agents/skills/continuous/SKILL.md
@@ -137,9 +137,7 @@ plans.
 
 Do not invent an unanswered product, data, architecture, auth, billing, or visual
 decision. Stop with the exact decision needed.
-Never stop for a reversible internal detail with no user-visible, security,
-persisted-data, interoperability, or cost consequence; choose the smaller
-repository-native option.
+Follow the proportional-engineering contract in `AGENTS.md` throughout this run.
 
 ### 2.2 Create or resume the feature branch
 
@@ -160,10 +158,6 @@ Build the spec in order, one small diff at a time. Continuous Mode does not paus
 for `workflow.stepReview`; its explicit invocation replaces those review
 prompts with self-review plus the final packet.
 
-Add an abstraction, dependency, service, configuration surface, compatibility
-layer, or security mechanism only when the approved spec or an established
-repository requirement needs it now.
-
 For each step:
 
 1. Implement only that step.
@@ -171,10 +165,8 @@ For each step:
 3. Run the exact documented `Verify` command when present. Otherwise run the
    documented build and existing relevant tests.
 4. Enforce `verification.logicTests` and `verification.uiEvidence`.
-5. Self-review scope, error paths, security boundaries, project conventions,
-   tests, and whether every new layer traces to a current requirement instead of
-   duplicating existing code, the standard library, the platform, or an installed
-   dependency.
+5. Self-review scope, error paths, security boundaries, project conventions, and
+   tests.
 6. Repair failures within scope, rerun affected evidence, and check off the step
    only when it passes.
 7. When `workflow.checkpointCommits` is `enabled`, create a conventional local

--- a/.agents/skills/discovery/SKILL.md
+++ b/.agents/skills/discovery/SKILL.md
@@ -64,6 +64,8 @@ Cover the areas that matter to this project, not a fixed questionnaire:
 - UI/UX direction, accessibility needs, and useful references
 - monetization or business model when relevant
 - deployment shape, environments, background work, storage, and operations
+- usage scale and real trust boundaries when they would materially change the
+  product or architecture
 - risks, assumptions, unresolved decisions, and how success will be judged
 - feature boundaries, dependencies, and a sensible build order
 
@@ -71,6 +73,13 @@ Depth is the goal. Follow a consequential answer until its implications are
 clear instead of racing to the next category. Do not ask the user to repeat facts
 already established in the conversation or repository. Do not force irrelevant
 topics merely to complete a checklist.
+
+Do not turn discovery into a scale or security questionnaire. Ask about users,
+reachability, trust, tenancy, compliance, or availability only when the answer
+would materially change the solution. Record explicit non-requirements such as
+local-only, trusted-team, single-user, or no-compliance scope when the user
+establishes them. A missing answer remains unknown and is not permission to
+invent enterprise machinery or ignore trust boundaries visible in the code.
 
 Periodically return a compact discovery snapshot with:
 
@@ -110,6 +119,9 @@ For `blueprint/project-plan.md`:
   conversation requires them
 - preserve rationale, examples, tradeoffs, constraints, edge cases, and
   exclusions that will matter during later feature work
+- put confirmed usage, reachability, trust, tenancy, security, compliance,
+  availability, audit constraints, and explicit non-requirements in the optional
+  usage-model section; leave it unanswered when those facts are not established
 - be as detailed as the project needs; never compress a rich discovery into a
   line or two per section
 - distinguish confirmed decisions from assumptions and TODOs

--- a/.agents/skills/discovery/SKILL.md
+++ b/.agents/skills/discovery/SKILL.md
@@ -64,8 +64,6 @@ Cover the areas that matter to this project, not a fixed questionnaire:
 - UI/UX direction, accessibility needs, and useful references
 - monetization or business model when relevant
 - deployment shape, environments, background work, storage, and operations
-- usage scale and real trust boundaries when they would materially change the
-  product or architecture
 - risks, assumptions, unresolved decisions, and how success will be judged
 - feature boundaries, dependencies, and a sensible build order
 
@@ -74,12 +72,9 @@ clear instead of racing to the next category. Do not ask the user to repeat fact
 already established in the conversation or repository. Do not force irrelevant
 topics merely to complete a checklist.
 
-Do not turn discovery into a scale or security questionnaire. Ask about users,
-reachability, trust, tenancy, compliance, or availability only when the answer
-would materially change the solution. Record explicit non-requirements such as
-local-only, trusted-team, single-user, or no-compliance scope when the user
-establishes them. A missing answer remains unknown and is not permission to
-invent enterprise machinery or ignore trust boundaries visible in the code.
+Follow the proportional-engineering contract in `AGENTS.md`: ask about optional
+usage or trust constraints only when they materially change the solution, record
+established non-requirements, and leave unknowns blank.
 
 Periodically return a compact discovery snapshot with:
 
@@ -119,9 +114,6 @@ For `blueprint/project-plan.md`:
   conversation requires them
 - preserve rationale, examples, tradeoffs, constraints, edge cases, and
   exclusions that will matter during later feature work
-- put confirmed usage, reachability, trust, tenancy, security, compliance,
-  availability, audit constraints, and explicit non-requirements in the optional
-  usage-model section; leave it unanswered when those facts are not established
 - be as detailed as the project needs; never compress a rich discovery into a
   line or two per section
 - distinguish confirmed decisions from assumptions and TODOs

--- a/.agents/skills/doctor/SKILL.md
+++ b/.agents/skills/doctor/SKILL.md
@@ -144,6 +144,9 @@ Gather these, then summarize. Do not dump file contents.
    - Check whether `blueprint/project-plan.md` and `blueprint/build-plan.md` look
      filled in or still template-like. Treat obvious TODO, TBD, example-only text,
      or empty required sections as not ready.
+   - The optional Usage model and constraints section may be blank, unanswered,
+     or still contain only the shipped worksheet prompts. Treat that as unknown
+     and healthy, not as an incomplete required section.
    - Check whether `blueprint/build-plan.md` is a numbered checkbox list. Raw
      bullets are allowed as a first draft, but they should be normalized by
      `/overview` before the build loop starts.

--- a/.agents/skills/doctor/SKILL.md
+++ b/.agents/skills/doctor/SKILL.md
@@ -144,9 +144,9 @@ Gather these, then summarize. Do not dump file contents.
    - Check whether `blueprint/project-plan.md` and `blueprint/build-plan.md` look
      filled in or still template-like. Treat obvious TODO, TBD, example-only text,
      or empty required sections as not ready.
-   - The optional Usage model and constraints section may be blank, unanswered,
-     or still contain only the shipped worksheet prompts. Treat that as unknown
-     and healthy, not as an incomplete required section.
+   - Follow the proportional-engineering contract in `AGENTS.md`: treat a blank
+     or template-only optional Usage model and constraints section as healthy
+     unknown context, not an incomplete requirement.
    - Check whether `blueprint/build-plan.md` is a numbered checkbox list. Raw
      bullets are allowed as a first draft, but they should be normalized by
      `/overview` before the build loop starts.

--- a/.agents/skills/feature/SKILL.md
+++ b/.agents/skills/feature/SKILL.md
@@ -40,8 +40,9 @@ Gather the smallest packet that can answer what must be built:
 
 1. Search `blueprint/context/project-overview.md` for the feature number, title,
    and distinctive nouns from the target line. Read the matching feature
-   passage plus only the data-model, stack, UI, security, or deployment passages
-   it directly depends on. Do not read the whole overview by default.
+   passage plus only the usage-model, data-model, stack, UI, security, or
+   deployment passages it directly depends on. Do not read the whole overview
+   by default.
 2. Inspect the repository once, starting from paths named by those passages.
    Follow only relevant imports, callers, tests, schemas, and configuration.
    Batch related searches and reads when supported.
@@ -75,6 +76,15 @@ the simplest repository-native option, record it in the spec, and require a test
 seam when the value is nondeterministic. Planned future persistence alone does
 not make a current in-memory representation a product decision when no stored
 data or external compatibility exists yet.
+
+Apply proportional engineering before drafting: add an abstraction, dependency,
+service, configuration surface, compatibility layer, or security mechanism only
+when an established requirement needs it now. Prefer existing code, the standard
+library, native platform features, and installed dependencies. Unknown scale or
+future extensibility defaults to the smaller reversible design. Treat a trust or
+data-integrity boundary as established when the repository exposes network or
+untrusted input, auth/session/ownership, shared persisted data, destructive
+operations, secrets, or sensitive data, even when the plans do not name it.
 
 If `project-overview.md` is 20,000 bytes or larger, stop and ask for `/overview`
 instead of loading it. If the target is too large for one reviewable branch,
@@ -134,8 +144,9 @@ creates the final feature commit.
 The spec must preserve every explicit contract in the feature packet, including
 applicable project-wide UX and security requirements. Do not discard a required
 state because the current fixture cannot trigger it yet. Keep later features out,
-define authorization and tenant boundaries, identify client and server
-responsibilities, and name exact files or areas supported by repository evidence.
+define authorization and tenant boundaries only when the feature packet or
+reachable code establishes them, identify client and server responsibilities,
+and name exact files or areas supported by repository evidence.
 Add focused tests for logic when a test command exists. Add browser coverage only
 when a Browser tests command exists and it is proportionate. Do not claim live,
 visual, persisted-data, or integration evidence that was not run.
@@ -163,13 +174,19 @@ Before the single write, check these failure classes:
   that applies to the feature.
 - A product contract from the packet that was omitted, weakened, or contradicted.
 - Scope added from guesswork or pulled forward from a later feature.
+- A proposed abstraction, dependency, service, configuration surface,
+  compatibility layer, or security mechanism lacks a current requirement, or
+  duplicates existing code, the standard library, the platform, or an installed
+  dependency. Untuned stack-specific standards in `coding-standards.md` are not
+  established requirements.
 - An oversized or incorrectly ordered build step.
-- A data or API contract leaves a required type, format or encoding, generator,
-  uniqueness rule, default, lifecycle state, serialization rule, or stable
-  result and error shape for later work to reinterpret.
-- A security-sensitive flow leaves the trusted actor source, repository-first
-  tenant scope, atomic uniqueness or mutation boundary, idempotency, or
-  redaction behavior implicit.
+- When an established persisted-data or external API boundary requires it, the
+  contract leaves a material type, format, encoding, generator, uniqueness rule,
+  default, lifecycle, serialization, or stable result and error shape implicit.
+- When an established security, tenant, concurrency, destructive-operation,
+  payment, or sensitive-data boundary requires it, the trusted actor source,
+  repository-first tenant scope, atomicity, idempotency, or redaction behavior
+  remains implicit.
 - User-controlled text lacks a safe rendering rule, or validation and error
   feedback lacks the relevant label, association, announcement, focus, or
   clearing behavior.

--- a/.agents/skills/feature/reference/feature-spec-template.md
+++ b/.agents/skills/feature/reference/feature-spec-template.md
@@ -49,11 +49,14 @@ session reads which boxes are ticked and resumes from the first unchecked step.
 ## Data / contracts
 
 - Schema, types, or API shapes involved, or "none yet."
-- For every material field or result, record the required type, format,
-  generation source, uniqueness, default, lifecycle, and error behavior that
-  implementation or later features must preserve.
-- For security-sensitive work, record the trusted actor source, tenant scope,
-  atomicity, idempotency, and redaction rules that apply.
+- For established persisted-data or external API boundaries, record only the
+  material type, format, generation source, uniqueness, default, lifecycle, and
+  error behavior that implementation or later features must preserve.
+- For established security, tenant, concurrency, destructive-operation, payment,
+  or sensitive-data boundaries, record the trusted actor source,
+  repository-first tenant scope, atomicity, idempotency, and redaction rules
+  that apply.
+- Do not create contracts or machinery for hypothetical future boundaries.
 
 ## Testing
 

--- a/.agents/skills/fix/SKILL.md
+++ b/.agents/skills/fix/SKILL.md
@@ -50,7 +50,12 @@ lighter than a feature spec:
   stamp makes the repair traceable: `/implement` marks that finding `fixed`
   when the repairing step lands, and `/audit` re-reviews it before it closes.
 - **The problem** - what's wrong or what needs to change, and where.
-- **The fix** - the approach, and anything it must not break.
+- **The fix** - the root-cause repair, and anything it must not break. Do not add
+  an abstraction, dependency, service, configuration surface, compatibility
+  layer, or security mechanism unless the defect is in that layer or an
+  established repository requirement needs it now. Adding a missing
+  authorization, ownership, validation, escaping, or redaction check is a
+  root-cause repair, not new machinery.
 - **Build steps** - usually one small step; split only if the diff would be too
   big to read. Each ends with an observable "done when".
 - **Verify** - how to confirm it's fixed (what to click or test).

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -58,6 +58,13 @@ Follow build steps in order. Build only what the spec says. If a step requires a
 unresolved product decision, unsafe action, missing prerequisite, or material
 scope expansion, stop and revise the spec instead of improvising.
 
+Add an abstraction, dependency, service, configuration surface, compatibility
+layer, or security mechanism only when the approved spec or an established
+repository requirement needs it now. Prefer existing code, the standard library,
+native platform features, and installed dependencies. If the simplest complete
+implementation conflicts with the spec, stop and revise the spec instead of
+silently building a larger design.
+
 For each step:
 
 1. Make the smallest coherent change that satisfies its `Done when`.
@@ -97,6 +104,13 @@ the finished diff. For user-facing work, inspect the reachability and error
 classification of each required state. Catch only known expected errors at a
 boundary; unexpected failures must reach the unexpected-error path. Fix any
 missing or contradicted contract before marking the spec verified.
+
+Run a proportionality check before final verification: every new abstraction,
+dependency, service, configuration surface, compatibility layer, and security
+mechanism must trace to the approved spec or an established repository
+requirement. Remove speculative machinery this work added without weakening real
+trust-boundary validation, data-loss prevention, accessibility, or configured
+verification.
 
 ## Verification
 

--- a/.agents/skills/onboard/SKILL.md
+++ b/.agents/skills/onboard/SKILL.md
@@ -143,6 +143,8 @@ Include only commands that exist or are intentionally available:
 If no test command exists, say so explicitly. Do not claim tests are a gate until
 a real test command is configured.
 
+Preserve the Proportional engineering contract in `AGENTS.md`.
+
 If `CLAUDE.md` exists and still has the placeholder `# Project Name`, replace it
 with the detected project name. Keep `@AGENTS.md`. Remove direct imports of
 `project-overview.md`, `current-feature.md`, `coding-standards.md`, and
@@ -155,6 +157,8 @@ Preserve unrelated user imports. Do not move detailed app context into
 Update `blueprint/context/coding-standards.md` so it matches the detected stack.
 Keep stable, tool-agnostic sections such as writing style, comments, scope, and
 testing philosophy. Replace stack-specific defaults that do not apply.
+Untuned stack-specific template defaults are not established project
+requirements.
 
 Cover the practical conventions the build loop needs:
 
@@ -278,7 +282,8 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  and coding conventions, but remove or avoid Blueprint workflow explanations,
+  coding conventions, and the Proportional engineering contract, but remove or
+  avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the

--- a/.agents/skills/onboard/SKILL.md
+++ b/.agents/skills/onboard/SKILL.md
@@ -143,7 +143,8 @@ Include only commands that exist or are intentionally available:
 If no test command exists, say so explicitly. Do not claim tests are a gate until
 a real test command is configured.
 
-Preserve the Proportional engineering contract in `AGENTS.md`.
+Follow and preserve the proportional-engineering contract in `AGENTS.md` when
+adapting commands, standards, and context to the detected project.
 
 If `CLAUDE.md` exists and still has the placeholder `# Project Name`, replace it
 with the detected project name. Keep `@AGENTS.md`. Remove direct imports of
@@ -157,8 +158,6 @@ Preserve unrelated user imports. Do not move detailed app context into
 Update `blueprint/context/coding-standards.md` so it matches the detected stack.
 Keep stable, tool-agnostic sections such as writing style, comments, scope, and
 testing philosophy. Replace stack-specific defaults that do not apply.
-Untuned stack-specific template defaults are not established project
-requirements.
 
 Cover the practical conventions the build loop needs:
 
@@ -282,8 +281,7 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  coding conventions, and the Proportional engineering contract, but remove or
-  avoid Blueprint workflow explanations,
+  and coding conventions, but remove or avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the

--- a/.agents/skills/overview/SKILL.md
+++ b/.agents/skills/overview/SKILL.md
@@ -32,7 +32,7 @@ context.
 The two planning docs, already written:
 
 - `blueprint/project-plan.md` - problem, users, features, data, tech,
-  monetization, UI/UX, deployment
+  monetization, UI/UX, deployment, and optional usage model
 - `blueprint/build-plan.md` - the ordered, one-line-per-feature list; bullets,
   numbered lists, and clearly separated feature lines are accepted
 
@@ -132,6 +132,12 @@ time this skill regenerates the overview.
 - **Carry deployment constraints forward.** If the plan names Render, Vercel,
   build commands, env vars, health checks, or provider constraints, include them
   in a short Deployment section. If deployment is unknown, mark it `> TODO`.
+- **Carry confirmed usage constraints forward.** Preserve established scale,
+  reachability, trust, tenancy, security, compliance, availability, audit
+  constraints, and explicit non-requirements in a compact Usage model section.
+  Omit it when the usage-model section, section 9 in the shipped worksheet, is
+  absent, unanswered, or contains only worksheet prompts. Never turn missing
+  usage facts into enterprise, hostile, multi-tenant, or single-user requirements.
 - **Stay faithful.** Don't add features, data, or stack choices that aren't in
   the plans. If something is underspecified, leave a clearly marked `> TODO`
   rather than inventing an answer.

--- a/.agents/skills/overview/reference/project-overview-template.md
+++ b/.agents/skills/overview/reference/project-overview-template.md
@@ -14,6 +14,14 @@ sentences: what's broken today and why it matters.
 Who this is for, from project-plan.md section 2. A short list of user types and
 what each one needs. Note any access tiers (e.g. anonymous vs signed-in).
 
+## Usage model
+
+Confirmed scale, reachability, trust, tenancy, security, compliance,
+availability, audit constraints, and explicit non-requirements from
+the usage-model section (section 9 in the shipped worksheet), when present. Omit
+this section when the plan establishes none of these facts. Never turn worksheet
+prompts or blank fields into requirements.
+
 ## Features
 
 The MVP feature set, in build-plan.md order - one line of purpose each. This is

--- a/.claude/skills/adopt/SKILL.md
+++ b/.claude/skills/adopt/SKILL.md
@@ -84,9 +84,6 @@ The code reveals *what* and *how*, never *why* or *what next*. Ask the user a sh
 set of questions (aim for three to five, not an interrogation) to fill the gaps:
 
 - What is this project for, and who uses it? (the problem and the users)
-- Are any material reachability or deployment constraints not already evident
-  from the code? Ask only when an answer would materially change the roadmap or
-  architecture; do not turn this into a scale or security questionnaire.
 - Is the stack and structure you found intentional, or are there parts they'd call
   legacy / want to change?
 - What do you want to build next? (the unchecked items in the build plan)
@@ -102,12 +99,9 @@ inference you're unsure of with a clear `> TODO (confirm)` so the user can corre
 it rather than inherit a wrong guess.
 
 - **`blueprint/project-plan.md`** - the what & why, following the existing
-  worksheet structure (problem, users, features, data, tech, monetization, UI/UX,
-  deployment, and optional usage model).
+  worksheet structure (problem, users, features, data, tech, monetization, UI/UX).
   The "features" and "tech" sections describe what *already exists*; the rest comes
-  from the interview. Record observed auth, ownership, reachability, tenancy, and
-  deployment facts before asking; leave unknown usage fields blank rather than
-  inventing requirements.
+  from the interview.
 - **`blueprint/build-plan.md`** - the ordered feature list as a checklist. **Mark
   shipped features `- [x]`** (this is the brownfield difference: the build plan
   reflects reality, so most of an existing app starts checked) and the roadmap
@@ -168,8 +162,7 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  coding conventions, and the Proportional engineering contract, but remove or
-  avoid Blueprint workflow explanations,
+  and coding conventions, but remove or avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the
@@ -207,8 +200,8 @@ the normal loop.
 - **Reflect reality, don't prescribe.** `coding-standards.md` must match the code
   that exists. A project using Zustand and REST routes should not be handed
   standards about Server Actions and Prisma just because that's the default.
-- Preserve the Proportional engineering contract in `AGENTS.md`; untuned
-  stack-specific template defaults are not established project requirements.
+- Follow and preserve the proportional-engineering contract in `AGENTS.md`;
+  record only established usage or trust constraints and leave unknowns blank.
 - **Never invent intent.** Ask for the why and the roadmap; mark anything inferred
   with `> TODO (confirm)`. Silent guesses about purpose are the main failure mode.
 - **Don't clobber owned work.** If the plans already have real content, confirm

--- a/.claude/skills/adopt/SKILL.md
+++ b/.claude/skills/adopt/SKILL.md
@@ -84,6 +84,9 @@ The code reveals *what* and *how*, never *why* or *what next*. Ask the user a sh
 set of questions (aim for three to five, not an interrogation) to fill the gaps:
 
 - What is this project for, and who uses it? (the problem and the users)
+- Are any material reachability or deployment constraints not already evident
+  from the code? Ask only when an answer would materially change the roadmap or
+  architecture; do not turn this into a scale or security questionnaire.
 - Is the stack and structure you found intentional, or are there parts they'd call
   legacy / want to change?
 - What do you want to build next? (the unchecked items in the build plan)
@@ -99,9 +102,12 @@ inference you're unsure of with a clear `> TODO (confirm)` so the user can corre
 it rather than inherit a wrong guess.
 
 - **`blueprint/project-plan.md`** - the what & why, following the existing
-  worksheet structure (problem, users, features, data, tech, monetization, UI/UX).
+  worksheet structure (problem, users, features, data, tech, monetization, UI/UX,
+  deployment, and optional usage model).
   The "features" and "tech" sections describe what *already exists*; the rest comes
-  from the interview.
+  from the interview. Record observed auth, ownership, reachability, tenancy, and
+  deployment facts before asking; leave unknown usage fields blank rather than
+  inventing requirements.
 - **`blueprint/build-plan.md`** - the ordered feature list as a checklist. **Mark
   shipped features `- [x]`** (this is the brownfield difference: the build plan
   reflects reality, so most of an existing app starts checked) and the roadmap
@@ -162,7 +168,8 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  and coding conventions, but remove or avoid Blueprint workflow explanations,
+  coding conventions, and the Proportional engineering contract, but remove or
+  avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the
@@ -200,6 +207,8 @@ the normal loop.
 - **Reflect reality, don't prescribe.** `coding-standards.md` must match the code
   that exists. A project using Zustand and REST routes should not be handed
   standards about Server Actions and Prisma just because that's the default.
+- Preserve the Proportional engineering contract in `AGENTS.md`; untuned
+  stack-specific template defaults are not established project requirements.
 - **Never invent intent.** Ask for the why and the roadmap; mark anything inferred
   with `> TODO (confirm)`. Silent guesses about purpose are the main failure mode.
 - **Don't clobber owned work.** If the plans already have real content, confirm

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -297,7 +297,10 @@ expectations. Apply only the selected lens or lenses:
 
 - **Quality:** duplicated logic, dead or unused code, unreachable paths,
   oversized modules, abstractions that do not pay for themselves, risky missing
-  abstractions, inconsistent patterns, and drift from the standards or spec.
+  abstractions, speculative dependencies, services, configuration surfaces,
+  compatibility layers or security machinery, inconsistent patterns, and drift
+  from the standards or spec. Untuned stack-specific template defaults are not
+  established requirements.
 - **Security:** missing authentication or authorization, client-controlled
   ownership, injection, unsafe parsing or deserialization, sensitive-data
   exposure, secret handling, insecure defaults, and trust-boundary mistakes.
@@ -315,6 +318,13 @@ expectations. Apply only the selected lens or lenses:
 
 Do not nitpick harmless style differences unless they signal drift from the local
 patterns. Prefer a short list of real findings over a broad list of guesses.
+
+For a proportionality finding, state in **Suggested fix** what can be deleted,
+which existing, standard-library, native-platform, or installed mechanism
+replaces it, and which current requirement would be lost. Use `None` when no
+current requirement would be lost. If the suggested fix removes or changes
+shipped behavior, require an explicit user decision and never describe it as an
+automatic repair.
 
 Do not broaden a focused pass because another category might be interesting.
 Do not report or call out non-critical concerns from omitted lenses, even as
@@ -414,6 +424,9 @@ Use P0 or P1 only when a concrete code path, violated contract or security
 boundary, failing command or test, or reproducible behavior confirms the risk. If
 the evidence is incomplete, list it under `Unverified risks` with the missing
 validation instead of presenting it as a confirmed high-severity finding.
+An otherwise pure proportionality finding is P2 or P3. Raise it to P0 or P1 only
+when the unnecessary machinery causes a concrete reachable defect or violates an
+established security or data-integrity boundary.
 
 If there are no findings, say that clearly for the selected lens and name any
 remaining risk or missing signal, such as "no test command declared" or

--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -118,12 +118,17 @@ If there is no active spec:
    - undefined contracts
    - missing design reference
    - scope creep
+   - speculative abstractions, dependencies, services, configuration surfaces,
+     compatibility layers, or security mechanisms
    - vague done-whens
    - missing testing plan when `AGENTS.md` declares a test command
 4. Apply the spec fixes.
 
 Autopilot may continue past this spec gate because the user explicitly invoked
 Autopilot. Still report what the critique changed in the final packet.
+Never stop for a reversible internal detail with no user-visible, security,
+persisted-data, interoperability, or cost consequence; choose the smaller
+repository-native option.
 
 ## Step 3 - create or reuse the branch
 
@@ -143,6 +148,10 @@ Do not pause for user approval after each passing step, regardless of the
 configured `workflow.stepReview` value. The review happens at the final packet
 unless a hard stop is hit.
 
+Add an abstraction, dependency, service, configuration surface, compatibility
+layer, or security mechanism only when the approved spec or an established
+repository requirement needs it now.
+
 For every step:
 
 1. Implement only that step.
@@ -161,6 +170,8 @@ For every step:
 4. Self-review the diff for the step:
    - does it match the spec?
    - did it add scope?
+   - does every new layer trace to a current requirement, and can existing code,
+     the standard library, the platform, or an installed dependency replace it?
    - is the error path handled?
    - did it follow `coding-standards.md`?
    - are tests present for new in-scope logic when the test gate is on?
@@ -259,8 +270,9 @@ For every finding:
    local project patterns. An audit finding is evidence to investigate, not an
    automatic instruction to edit.
 2. Repair confirmed P0 and P1 findings when the fix stays inside the approved
-   feature scope and does not require a product or architecture decision. Set
-   the repaired finding to `fixed` in the ledger, never `closed`.
+   feature scope, does not require a product or architecture decision, and does
+   not remove or change shipped behavior. Set the repaired finding to `fixed` in
+   the ledger, never `closed`.
 3. Report P2 and P3 findings in the final packet. Fix them only when the change
    is small, directly caused by the current feature, and clearly required by the
    project standards.

--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -118,17 +118,13 @@ If there is no active spec:
    - undefined contracts
    - missing design reference
    - scope creep
-   - speculative abstractions, dependencies, services, configuration surfaces,
-     compatibility layers, or security mechanisms
    - vague done-whens
    - missing testing plan when `AGENTS.md` declares a test command
 4. Apply the spec fixes.
 
 Autopilot may continue past this spec gate because the user explicitly invoked
 Autopilot. Still report what the critique changed in the final packet.
-Never stop for a reversible internal detail with no user-visible, security,
-persisted-data, interoperability, or cost consequence; choose the smaller
-repository-native option.
+Follow the proportional-engineering contract in `AGENTS.md` throughout this run.
 
 ## Step 3 - create or reuse the branch
 
@@ -148,10 +144,6 @@ Do not pause for user approval after each passing step, regardless of the
 configured `workflow.stepReview` value. The review happens at the final packet
 unless a hard stop is hit.
 
-Add an abstraction, dependency, service, configuration surface, compatibility
-layer, or security mechanism only when the approved spec or an established
-repository requirement needs it now.
-
 For every step:
 
 1. Implement only that step.
@@ -170,8 +162,6 @@ For every step:
 4. Self-review the diff for the step:
    - does it match the spec?
    - did it add scope?
-   - does every new layer trace to a current requirement, and can existing code,
-     the standard library, the platform, or an installed dependency replace it?
    - is the error path handled?
    - did it follow `coding-standards.md`?
    - are tests present for new in-scope logic when the test gate is on?

--- a/.claude/skills/continuous/SKILL.md
+++ b/.claude/skills/continuous/SKILL.md
@@ -138,9 +138,7 @@ plans.
 
 Do not invent an unanswered product, data, architecture, auth, billing, or visual
 decision. Stop with the exact decision needed.
-Never stop for a reversible internal detail with no user-visible, security,
-persisted-data, interoperability, or cost consequence; choose the smaller
-repository-native option.
+Follow the proportional-engineering contract in `AGENTS.md` throughout this run.
 
 ### 2.2 Create or resume the feature branch
 
@@ -161,10 +159,6 @@ Build the spec in order, one small diff at a time. Continuous Mode does not paus
 for `workflow.stepReview`; its explicit invocation replaces those review
 prompts with self-review plus the final packet.
 
-Add an abstraction, dependency, service, configuration surface, compatibility
-layer, or security mechanism only when the approved spec or an established
-repository requirement needs it now.
-
 For each step:
 
 1. Implement only that step.
@@ -172,10 +166,8 @@ For each step:
 3. Run the exact documented `Verify` command when present. Otherwise run the
    documented build and existing relevant tests.
 4. Enforce `verification.logicTests` and `verification.uiEvidence`.
-5. Self-review scope, error paths, security boundaries, project conventions,
-   tests, and whether every new layer traces to a current requirement instead of
-   duplicating existing code, the standard library, the platform, or an installed
-   dependency.
+5. Self-review scope, error paths, security boundaries, project conventions, and
+   tests.
 6. Repair failures within scope, rerun affected evidence, and check off the step
    only when it passes.
 7. When `workflow.checkpointCommits` is `enabled`, create a conventional local

--- a/.claude/skills/continuous/SKILL.md
+++ b/.claude/skills/continuous/SKILL.md
@@ -138,6 +138,9 @@ plans.
 
 Do not invent an unanswered product, data, architecture, auth, billing, or visual
 decision. Stop with the exact decision needed.
+Never stop for a reversible internal detail with no user-visible, security,
+persisted-data, interoperability, or cost consequence; choose the smaller
+repository-native option.
 
 ### 2.2 Create or resume the feature branch
 
@@ -158,6 +161,10 @@ Build the spec in order, one small diff at a time. Continuous Mode does not paus
 for `workflow.stepReview`; its explicit invocation replaces those review
 prompts with self-review plus the final packet.
 
+Add an abstraction, dependency, service, configuration surface, compatibility
+layer, or security mechanism only when the approved spec or an established
+repository requirement needs it now.
+
 For each step:
 
 1. Implement only that step.
@@ -165,8 +172,10 @@ For each step:
 3. Run the exact documented `Verify` command when present. Otherwise run the
    documented build and existing relevant tests.
 4. Enforce `verification.logicTests` and `verification.uiEvidence`.
-5. Self-review scope, error paths, security boundaries, project conventions, and
-   tests.
+5. Self-review scope, error paths, security boundaries, project conventions,
+   tests, and whether every new layer traces to a current requirement instead of
+   duplicating existing code, the standard library, the platform, or an installed
+   dependency.
 6. Repair failures within scope, rerun affected evidence, and check off the step
    only when it passes.
 7. When `workflow.checkpointCommits` is `enabled`, create a conventional local
@@ -210,9 +219,10 @@ blockers always apply even when audit is manual.
 ### 2.5 Repair and re-review findings
 
 Validate audit findings before editing. Repair confirmed P0 and P1 findings only
-when the repair stays within feature scope and needs no user decision. Use
-`continuous.maxRepairAttempts` as the maximum attempts for the same failing
-check or finding; `0` disables automatic repair.
+when the repair stays within feature scope, needs no user decision, and does not
+remove or change shipped behavior. Use `continuous.maxRepairAttempts` as the
+maximum attempts for the same failing check or finding; `0` disables automatic
+repair.
 
 After a repair, rerun affected verification and acceptance evidence, then
 re-audit the repaired area. Move `fixed` to `closed` only when the audit

--- a/.claude/skills/discovery/SKILL.md
+++ b/.claude/skills/discovery/SKILL.md
@@ -65,8 +65,6 @@ Cover the areas that matter to this project, not a fixed questionnaire:
 - UI/UX direction, accessibility needs, and useful references
 - monetization or business model when relevant
 - deployment shape, environments, background work, storage, and operations
-- usage scale and real trust boundaries when they would materially change the
-  product or architecture
 - risks, assumptions, unresolved decisions, and how success will be judged
 - feature boundaries, dependencies, and a sensible build order
 
@@ -75,12 +73,9 @@ clear instead of racing to the next category. Do not ask the user to repeat fact
 already established in the conversation or repository. Do not force irrelevant
 topics merely to complete a checklist.
 
-Do not turn discovery into a scale or security questionnaire. Ask about users,
-reachability, trust, tenancy, compliance, or availability only when the answer
-would materially change the solution. Record explicit non-requirements such as
-local-only, trusted-team, single-user, or no-compliance scope when the user
-establishes them. A missing answer remains unknown and is not permission to
-invent enterprise machinery or ignore trust boundaries visible in the code.
+Follow the proportional-engineering contract in `AGENTS.md`: ask about optional
+usage or trust constraints only when they materially change the solution, record
+established non-requirements, and leave unknowns blank.
 
 Periodically return a compact discovery snapshot with:
 
@@ -120,9 +115,6 @@ For `blueprint/project-plan.md`:
   conversation requires them
 - preserve rationale, examples, tradeoffs, constraints, edge cases, and
   exclusions that will matter during later feature work
-- put confirmed usage, reachability, trust, tenancy, security, compliance,
-  availability, audit constraints, and explicit non-requirements in the optional
-  usage-model section; leave it unanswered when those facts are not established
 - be as detailed as the project needs; never compress a rich discovery into a
   line or two per section
 - distinguish confirmed decisions from assumptions and TODOs

--- a/.claude/skills/discovery/SKILL.md
+++ b/.claude/skills/discovery/SKILL.md
@@ -65,6 +65,8 @@ Cover the areas that matter to this project, not a fixed questionnaire:
 - UI/UX direction, accessibility needs, and useful references
 - monetization or business model when relevant
 - deployment shape, environments, background work, storage, and operations
+- usage scale and real trust boundaries when they would materially change the
+  product or architecture
 - risks, assumptions, unresolved decisions, and how success will be judged
 - feature boundaries, dependencies, and a sensible build order
 
@@ -72,6 +74,13 @@ Depth is the goal. Follow a consequential answer until its implications are
 clear instead of racing to the next category. Do not ask the user to repeat facts
 already established in the conversation or repository. Do not force irrelevant
 topics merely to complete a checklist.
+
+Do not turn discovery into a scale or security questionnaire. Ask about users,
+reachability, trust, tenancy, compliance, or availability only when the answer
+would materially change the solution. Record explicit non-requirements such as
+local-only, trusted-team, single-user, or no-compliance scope when the user
+establishes them. A missing answer remains unknown and is not permission to
+invent enterprise machinery or ignore trust boundaries visible in the code.
 
 Periodically return a compact discovery snapshot with:
 
@@ -111,6 +120,9 @@ For `blueprint/project-plan.md`:
   conversation requires them
 - preserve rationale, examples, tradeoffs, constraints, edge cases, and
   exclusions that will matter during later feature work
+- put confirmed usage, reachability, trust, tenancy, security, compliance,
+  availability, audit constraints, and explicit non-requirements in the optional
+  usage-model section; leave it unanswered when those facts are not established
 - be as detailed as the project needs; never compress a rich discovery into a
   line or two per section
 - distinguish confirmed decisions from assumptions and TODOs

--- a/.claude/skills/doctor/SKILL.md
+++ b/.claude/skills/doctor/SKILL.md
@@ -145,9 +145,9 @@ Gather these, then summarize. Do not dump file contents.
    - Check whether `blueprint/project-plan.md` and `blueprint/build-plan.md` look
      filled in or still template-like. Treat obvious TODO, TBD, example-only text,
      or empty required sections as not ready.
-   - The optional Usage model and constraints section may be blank, unanswered,
-     or still contain only the shipped worksheet prompts. Treat that as unknown
-     and healthy, not as an incomplete required section.
+   - Follow the proportional-engineering contract in `AGENTS.md`: treat a blank
+     or template-only optional Usage model and constraints section as healthy
+     unknown context, not an incomplete requirement.
    - Check whether `blueprint/build-plan.md` is a numbered checkbox list. Raw
      bullets are allowed as a first draft, but they should be normalized by
      `/overview` before the build loop starts.

--- a/.claude/skills/doctor/SKILL.md
+++ b/.claude/skills/doctor/SKILL.md
@@ -145,6 +145,9 @@ Gather these, then summarize. Do not dump file contents.
    - Check whether `blueprint/project-plan.md` and `blueprint/build-plan.md` look
      filled in or still template-like. Treat obvious TODO, TBD, example-only text,
      or empty required sections as not ready.
+   - The optional Usage model and constraints section may be blank, unanswered,
+     or still contain only the shipped worksheet prompts. Treat that as unknown
+     and healthy, not as an incomplete required section.
    - Check whether `blueprint/build-plan.md` is a numbered checkbox list. Raw
      bullets are allowed as a first draft, but they should be normalized by
      `/overview` before the build loop starts.

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -41,8 +41,9 @@ Gather the smallest packet that can answer what must be built:
 
 1. Search `blueprint/context/project-overview.md` for the feature number, title,
    and distinctive nouns from the target line. Read the matching feature
-   passage plus only the data-model, stack, UI, security, or deployment passages
-   it directly depends on. Do not read the whole overview by default.
+   passage plus only the usage-model, data-model, stack, UI, security, or
+   deployment passages it directly depends on. Do not read the whole overview
+   by default.
 2. Inspect the repository once, starting from paths named by those passages.
    Follow only relevant imports, callers, tests, schemas, and configuration.
    Batch related searches and reads when supported.
@@ -76,6 +77,15 @@ the simplest repository-native option, record it in the spec, and require a test
 seam when the value is nondeterministic. Planned future persistence alone does
 not make a current in-memory representation a product decision when no stored
 data or external compatibility exists yet.
+
+Apply proportional engineering before drafting: add an abstraction, dependency,
+service, configuration surface, compatibility layer, or security mechanism only
+when an established requirement needs it now. Prefer existing code, the standard
+library, native platform features, and installed dependencies. Unknown scale or
+future extensibility defaults to the smaller reversible design. Treat a trust or
+data-integrity boundary as established when the repository exposes network or
+untrusted input, auth/session/ownership, shared persisted data, destructive
+operations, secrets, or sensitive data, even when the plans do not name it.
 
 If `project-overview.md` is 20,000 bytes or larger, stop and ask for `/overview`
 instead of loading it. If the target is too large for one reviewable branch,
@@ -135,8 +145,9 @@ creates the final feature commit.
 The spec must preserve every explicit contract in the feature packet, including
 applicable project-wide UX and security requirements. Do not discard a required
 state because the current fixture cannot trigger it yet. Keep later features out,
-define authorization and tenant boundaries, identify client and server
-responsibilities, and name exact files or areas supported by repository evidence.
+define authorization and tenant boundaries only when the feature packet or
+reachable code establishes them, identify client and server responsibilities,
+and name exact files or areas supported by repository evidence.
 Add focused tests for logic when a test command exists. Add browser coverage only
 when a Browser tests command exists and it is proportionate. Do not claim live,
 visual, persisted-data, or integration evidence that was not run.
@@ -164,13 +175,19 @@ Before the single write, check these failure classes:
   that applies to the feature.
 - A product contract from the packet that was omitted, weakened, or contradicted.
 - Scope added from guesswork or pulled forward from a later feature.
+- A proposed abstraction, dependency, service, configuration surface,
+  compatibility layer, or security mechanism lacks a current requirement, or
+  duplicates existing code, the standard library, the platform, or an installed
+  dependency. Untuned stack-specific standards in `coding-standards.md` are not
+  established requirements.
 - An oversized or incorrectly ordered build step.
-- A data or API contract leaves a required type, format or encoding, generator,
-  uniqueness rule, default, lifecycle state, serialization rule, or stable
-  result and error shape for later work to reinterpret.
-- A security-sensitive flow leaves the trusted actor source, repository-first
-  tenant scope, atomic uniqueness or mutation boundary, idempotency, or
-  redaction behavior implicit.
+- When an established persisted-data or external API boundary requires it, the
+  contract leaves a material type, format, encoding, generator, uniqueness rule,
+  default, lifecycle, serialization, or stable result and error shape implicit.
+- When an established security, tenant, concurrency, destructive-operation,
+  payment, or sensitive-data boundary requires it, the trusted actor source,
+  repository-first tenant scope, atomicity, idempotency, or redaction behavior
+  remains implicit.
 - User-controlled text lacks a safe rendering rule, or validation and error
   feedback lacks the relevant label, association, announcement, focus, or
   clearing behavior.

--- a/.claude/skills/feature/reference/feature-spec-template.md
+++ b/.claude/skills/feature/reference/feature-spec-template.md
@@ -49,11 +49,14 @@ session reads which boxes are ticked and resumes from the first unchecked step.
 ## Data / contracts
 
 - Schema, types, or API shapes involved, or "none yet."
-- For every material field or result, record the required type, format,
-  generation source, uniqueness, default, lifecycle, and error behavior that
-  implementation or later features must preserve.
-- For security-sensitive work, record the trusted actor source, tenant scope,
-  atomicity, idempotency, and redaction rules that apply.
+- For established persisted-data or external API boundaries, record only the
+  material type, format, generation source, uniqueness, default, lifecycle, and
+  error behavior that implementation or later features must preserve.
+- For established security, tenant, concurrency, destructive-operation, payment,
+  or sensitive-data boundaries, record the trusted actor source,
+  repository-first tenant scope, atomicity, idempotency, and redaction rules
+  that apply.
+- Do not create contracts or machinery for hypothetical future boundaries.
 
 ## Testing
 

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -51,7 +51,12 @@ lighter than a feature spec:
   stamp makes the repair traceable: `/implement` marks that finding `fixed`
   when the repairing step lands, and `/audit` re-reviews it before it closes.
 - **The problem** - what's wrong or what needs to change, and where.
-- **The fix** - the approach, and anything it must not break.
+- **The fix** - the root-cause repair, and anything it must not break. Do not add
+  an abstraction, dependency, service, configuration surface, compatibility
+  layer, or security mechanism unless the defect is in that layer or an
+  established repository requirement needs it now. Adding a missing
+  authorization, ownership, validation, escaping, or redaction check is a
+  root-cause repair, not new machinery.
 - **Build steps** - usually one small step; split only if the diff would be too
   big to read. Each ends with an observable "done when".
 - **Verify** - how to confirm it's fixed (what to click or test).

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -59,6 +59,13 @@ Follow build steps in order. Build only what the spec says. If a step requires a
 unresolved product decision, unsafe action, missing prerequisite, or material
 scope expansion, stop and revise the spec instead of improvising.
 
+Add an abstraction, dependency, service, configuration surface, compatibility
+layer, or security mechanism only when the approved spec or an established
+repository requirement needs it now. Prefer existing code, the standard library,
+native platform features, and installed dependencies. If the simplest complete
+implementation conflicts with the spec, stop and revise the spec instead of
+silently building a larger design.
+
 For each step:
 
 1. Make the smallest coherent change that satisfies its `Done when`.
@@ -98,6 +105,13 @@ the finished diff. For user-facing work, inspect the reachability and error
 classification of each required state. Catch only known expected errors at a
 boundary; unexpected failures must reach the unexpected-error path. Fix any
 missing or contradicted contract before marking the spec verified.
+
+Run a proportionality check before final verification: every new abstraction,
+dependency, service, configuration surface, compatibility layer, and security
+mechanism must trace to the approved spec or an established repository
+requirement. Remove speculative machinery this work added without weakening real
+trust-boundary validation, data-loss prevention, accessibility, or configured
+verification.
 
 ## Verification
 

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -144,7 +144,8 @@ Include only commands that exist or are intentionally available:
 If no test command exists, say so explicitly. Do not claim tests are a gate until
 a real test command is configured.
 
-Preserve the Proportional engineering contract in `AGENTS.md`.
+Follow and preserve the proportional-engineering contract in `AGENTS.md` when
+adapting commands, standards, and context to the detected project.
 
 If `CLAUDE.md` exists and still has the placeholder `# Project Name`, replace it
 with the detected project name. Keep `@AGENTS.md`. Remove direct imports of
@@ -158,8 +159,6 @@ Preserve unrelated user imports. Do not move detailed app context into
 Update `blueprint/context/coding-standards.md` so it matches the detected stack.
 Keep stable, tool-agnostic sections such as writing style, comments, scope, and
 testing philosophy. Replace stack-specific defaults that do not apply.
-Untuned stack-specific template defaults are not established project
-requirements.
 
 Cover the practical conventions the build loop needs:
 
@@ -283,8 +282,7 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  coding conventions, and the Proportional engineering contract, but remove or
-  avoid Blueprint workflow explanations,
+  and coding conventions, but remove or avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -144,6 +144,8 @@ Include only commands that exist or are intentionally available:
 If no test command exists, say so explicitly. Do not claim tests are a gate until
 a real test command is configured.
 
+Preserve the Proportional engineering contract in `AGENTS.md`.
+
 If `CLAUDE.md` exists and still has the placeholder `# Project Name`, replace it
 with the detected project name. Keep `@AGENTS.md`. Remove direct imports of
 `project-overview.md`, `current-feature.md`, `coding-standards.md`, and
@@ -156,6 +158,8 @@ Preserve unrelated user imports. Do not move detailed app context into
 Update `blueprint/context/coding-standards.md` so it matches the detected stack.
 Keep stable, tool-agnostic sections such as writing style, comments, scope, and
 testing philosophy. Replace stack-specific defaults that do not apply.
+Untuned stack-specific template defaults are not established project
+requirements.
 
 Cover the practical conventions the build loop needs:
 
@@ -279,7 +283,8 @@ Recommend option 1 by default. If the user chooses option 2:
 - Keep `AGENTS.md` tracked. It remains the lightweight public project guide for
   commands and conventions.
 - Make `AGENTS.md` public-safe: keep project description, commands, testing gate,
-  and coding conventions, but remove or avoid Blueprint workflow explanations,
+  coding conventions, and the Proportional engineering contract, but remove or
+  avoid Blueprint workflow explanations,
   hidden adapter paths, workflow-document pointers, and core skill lists that
   would expose the local-only workflow.
 - Explain that local-only mode hides the workflow contents from the repo, but the

--- a/.claude/skills/overview/SKILL.md
+++ b/.claude/skills/overview/SKILL.md
@@ -33,7 +33,7 @@ context.
 The two planning docs, already written:
 
 - `blueprint/project-plan.md` - problem, users, features, data, tech,
-  monetization, UI/UX, deployment
+  monetization, UI/UX, deployment, and optional usage model
 - `blueprint/build-plan.md` - the ordered, one-line-per-feature list; bullets,
   numbered lists, and clearly separated feature lines are accepted
 
@@ -133,6 +133,12 @@ time this skill regenerates the overview.
 - **Carry deployment constraints forward.** If the plan names Render, Vercel,
   build commands, env vars, health checks, or provider constraints, include them
   in a short Deployment section. If deployment is unknown, mark it `> TODO`.
+- **Carry confirmed usage constraints forward.** Preserve established scale,
+  reachability, trust, tenancy, security, compliance, availability, audit
+  constraints, and explicit non-requirements in a compact Usage model section.
+  Omit it when the usage-model section, section 9 in the shipped worksheet, is
+  absent, unanswered, or contains only worksheet prompts. Never turn missing
+  usage facts into enterprise, hostile, multi-tenant, or single-user requirements.
 - **Stay faithful.** Don't add features, data, or stack choices that aren't in
   the plans. If something is underspecified, leave a clearly marked `> TODO`
   rather than inventing an answer.

--- a/.claude/skills/overview/reference/project-overview-template.md
+++ b/.claude/skills/overview/reference/project-overview-template.md
@@ -14,6 +14,14 @@ sentences: what's broken today and why it matters.
 Who this is for, from project-plan.md section 2. A short list of user types and
 what each one needs. Note any access tiers (e.g. anonymous vs signed-in).
 
+## Usage model
+
+Confirmed scale, reachability, trust, tenancy, security, compliance,
+availability, audit constraints, and explicit non-requirements from
+the usage-model section (section 9 in the shipped worksheet), when present. Omit
+this section when the plan establishes none of these facts. Never turn worksheet
+prompts or blank fields into requirements.
+
 ## Features
 
 The MVP feature set, in build-plan.md order - one line of purpose each. This is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,26 @@ because the directory isn't empty.
 
 The workflow is defined by the local skills and context files below.
 
+## Proportional engineering
+
+Build for established requirements, not hypothetical scale, threats, or future
+flexibility. Reuse existing code, the standard library, native platform features,
+and installed dependencies before adding machinery.
+
+- Unknown scale or extensibility defaults to the smaller reversible design. Do
+  not infer enterprise, multi-tenant, hostile-user, or compliance requirements.
+- Derive trust and data-integrity boundaries from actual reachability: untrusted
+  input, auth/session/ownership, shared persisted data, destructive operations,
+  payments, secrets, and sensitive data.
+- Ask only when an unknown materially changes behavior, architecture, persisted
+  data, interoperability, a real security boundary, or cost. Otherwise choose the
+  simplest repository-native implementation.
+- Add an abstraction, dependency, service, configuration surface, compatibility
+  layer, or security mechanism only for a current requirement.
+- Simplicity never removes real trust-boundary validation, data-loss prevention,
+  accessibility, explicit security requirements, configured tests, or project rules.
+- Stack-specific template standards apply only when the project uses that stack.
+
 ## Read these when relevant
 
 - `blueprint/config.json` - deterministic project workflow settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ published `create-ai-blueprint` package.
 
 ## [Unreleased]
 
+### Added
+
+- Added proportional-engineering guidance across planning, specification,
+  implementation, automated workflows, and audit. New abstractions,
+  dependencies, services, configuration, and specialized security machinery
+  now require a current need, reducing unnecessary generated code and repeated
+  context while preserving real trust and data-integrity boundaries.
+
 ### Fixed
 
 - Made `npm run link:local` safely repeatable by replacing its existing global

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Blueprint adds a controlled loop:
 
 - **Spec before code.** The agent writes a feature or fix spec and stops for
   review before implementation.
+- **Proportional engineering.** Plans and builds require a current need before
+  adding abstractions, dependencies, services, configuration, or specialized
+  security machinery. Unknown scale defaults to the smaller reversible design,
+  while real trust and data-integrity boundaries still apply.
 - **Explain the result.** Every completed implementation offers a read-only code
   walkthrough, regardless of the configured review cadence.
 - **One work item at a time.** The current feature, fix, or rollback has one

--- a/blueprint/project-plan.md
+++ b/blueprint/project-plan.md
@@ -40,3 +40,12 @@ Describe the look and feel. Add examples if you want
 Target host if known, such as Render or Vercel. Include app type, build command,
 start command or output directory, env vars by name, database or storage needs,
 workers or cron jobs, health check path, and domain notes if you know them.
+
+## 9. Usage model and constraints (optional)
+
+Record only what is known and relevant: expected user count and approximate scale;
+local, internal, or internet-facing operation; trusted or adversarial users;
+single-tenant or multi-tenant use when applicable; required security, compliance,
+availability, or audit constraints; and explicit non-requirements. Leave this
+section unanswered when those facts are not established. Unknown does not mean
+enterprise, hostile, multi-tenant, or single-user.

--- a/packages/create-ai-blueprint/README.md
+++ b/packages/create-ai-blueprint/README.md
@@ -8,6 +8,11 @@ It works with any stack and installs inside an app you have already scaffolded.
 Plans, specs, project context, findings, configuration, and completed-work
 history stay as readable files in your repository.
 
+Across that workflow, proportional-engineering guidance keeps plans and code
+limited to current requirements. It prefers existing project and platform
+capabilities before new machinery while preserving real trust and data-integrity
+boundaries.
+
 [![npm version](https://img.shields.io/npm/v/create-ai-blueprint?style=flat-square&color=155eef)](https://www.npmjs.com/package/create-ai-blueprint)
 [![Validate Blueprint](https://github.com/aiblueprinthq/ai-blueprint/actions/workflows/validate.yml/badge.svg)](https://github.com/aiblueprinthq/ai-blueprint/actions/workflows/validate.yml)
 [![MIT license](https://img.shields.io/npm/l/create-ai-blueprint?style=flat-square&color=155eef)](LICENSE)

--- a/scripts/e2e/scenarios/autopilot-boundary.ts
+++ b/scripts/e2e/scenarios/autopilot-boundary.ts
@@ -21,6 +21,7 @@ Print \`Hello, world!\` and make no other product change.
 Run \`npm run build\`, then run \`node src/greeting.js\`.
 `;
 
+import fs from "node:fs";
 import type { Runner } from "../harness.js";
 
 async function run(t: Runner) {
@@ -48,10 +49,22 @@ async function run(t: Runner) {
   );
   t.write("src/greeting.js", 'console.log("Hello world");\n');
   t.write("blueprint/context/current-feature.md", FIX_SPEC);
+  const configText = t.read("blueprint/config.json");
+  if (configText === null) throw new Error("Fixture is missing blueprint/config.json.");
+  const config = JSON.parse(configText);
+  config.workflow.checkpointCommits = "enabled";
+  config.qualityGates.regular.independentReview = "manual";
+  t.write("blueprint/config.json", JSON.stringify(config, null, 2) + "\n");
   t.gitInit();
   t.git("add", "-A");
   t.git("commit", "-m", "chore: create autopilot fixture");
   const mainBefore = t.git("rev-parse", "main");
+  const packageBefore = t.read("package.json");
+  const directoriesBefore = fs
+    .readdirSync(t.workspace, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
+    .map((entry) => entry.name)
+    .sort();
 
   t.phase("autopilot builds and checks but stops before completion");
   const result = t.agent(
@@ -59,12 +72,38 @@ async function run(t: Runner) {
   );
   const currentBranch = t.git("branch", "--show-current");
   const currentFeature = t.read("blueprint/context/current-feature.md") || "";
+  const changedPaths = [
+    ...new Set([
+      ...t.git("diff", "--name-only", `main...${currentBranch}`).split("\n").filter(Boolean),
+      ...t
+        .git("status", "--porcelain")
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => line.replace(/^[ MADRCU?!]{1,2}\s+/, ""))
+    ])
+  ].filter((relativePath) => relativePath !== "node_modules/");
 
   t.check("agent invocation succeeded", result.status === 0);
   t.check("main was not advanced", t.git("rev-parse", "main") === mainBefore);
   t.check("work remains on a fix branch", currentBranch.startsWith("fix/"));
   t.check("the greeting was corrected",   (t.read("src/greeting.js") ?? "").includes("Hello, world!"));
   t.check("the implementation step was checked", currentFeature.includes("- [x] 1."));
+  t.check("package metadata stayed byte-identical", t.read("package.json") === packageBefore);
+  t.check(
+    "only the source and current spec changed",
+    changedPaths.sort().join("\n") ===
+      ["blueprint/context/current-feature.md", "src/greeting.js"].join("\n")
+  );
+  t.check(
+    "no top-level directories were added",
+    JSON.stringify(
+      fs
+        .readdirSync(t.workspace, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
+        .map((entry) => entry.name)
+        .sort()
+    ) === JSON.stringify(directoriesBefore)
+  );
   t.check(
     "main still contains the original greeting",
     t.git("show", "main:src/greeting.js").includes("Hello world")

--- a/scripts/e2e/scenarios/autopilot-boundary.ts
+++ b/scripts/e2e/scenarios/autopilot-boundary.ts
@@ -49,12 +49,6 @@ async function run(t: Runner) {
   );
   t.write("src/greeting.js", 'console.log("Hello world");\n');
   t.write("blueprint/context/current-feature.md", FIX_SPEC);
-  const configText = t.read("blueprint/config.json");
-  if (configText === null) throw new Error("Fixture is missing blueprint/config.json.");
-  const config = JSON.parse(configText);
-  config.workflow.checkpointCommits = "enabled";
-  config.qualityGates.regular.independentReview = "manual";
-  t.write("blueprint/config.json", JSON.stringify(config, null, 2) + "\n");
   t.gitInit();
   t.git("add", "-A");
   t.git("commit", "-m", "chore: create autopilot fixture");
@@ -109,8 +103,8 @@ async function run(t: Runner) {
     t.git("show", "main:src/greeting.js").includes("Hello world")
   );
   t.check(
-    "the fix branch contains at least one checkpoint commit",
-    Number(t.git("rev-list", "--count", `main..${currentBranch}`)) >= 1
+    "checkpoint commits stay disabled by default",
+    Number(t.git("rev-list", "--count", `main..${currentBranch}`)) === 0
   );
   t.check(
     "no completion archive was added",
@@ -120,6 +114,6 @@ async function run(t: Runner) {
 
 export default {
   name: "autopilot-boundary",
-  description: "Autopilot may checkpoint passing work but cannot complete or merge it",
+  description: "Autopilot respects default checkpoint policy and cannot complete or merge",
   run
 };

--- a/scripts/e2e/scenarios/feature-gate.ts
+++ b/scripts/e2e/scenarios/feature-gate.ts
@@ -91,10 +91,6 @@ async function run(t: Runner) {
   t.check("product source was not edited", t.read("src/greeting.js") === sourceBefore);
   t.check("package metadata was not edited", t.read("package.json") === packageBefore);
   t.check(
-    "no dependency installation was added to the spec",
-    !/(?:^|`)[^\S\n]*(?:npm (?:install|i|add)|pnpm (?:add|install)|yarn add|bun add)(?:[^\S\n]+-{1,2}[\w-]+)*[^\S\n]+(?!-)[@\w]/im.test(currentFeature)
-  );
-  t.check(
     "no top-level directories were added",
     JSON.stringify(
       fs

--- a/scripts/e2e/scenarios/feature-gate.ts
+++ b/scripts/e2e/scenarios/feature-gate.ts
@@ -38,6 +38,7 @@ Feature 1 adds an optional name while preserving the default greeting.
 - Do not add dependencies.
 `;
 
+import fs from "node:fs";
 import type { Runner } from "../harness.js";
 
 async function run(t: Runner) {
@@ -46,12 +47,30 @@ async function run(t: Runner) {
   t.write("blueprint/project-plan.md", PROJECT_PLAN);
   t.write("blueprint/build-plan.md", BUILD_PLAN);
   t.write("blueprint/context/project-overview.md", PROJECT_OVERVIEW);
+  t.write(
+    "package.json",
+    JSON.stringify(
+      {
+        name: "feature-gate-fixture",
+        private: true,
+        scripts: { build: "node --check src/greeting.js" }
+      },
+      null,
+      2
+    ) + "\n"
+  );
   t.write("src/greeting.js", 'console.log("Hello, world!");\n');
   t.gitInit();
   t.git("add", "-A");
   t.git("commit", "-m", "chore: create feature planning fixture");
   const headBefore = t.git("rev-parse", "HEAD");
   const sourceBefore = t.read("src/greeting.js");
+  const packageBefore = t.read("package.json");
+  const directoriesBefore = fs
+    .readdirSync(t.workspace, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
+    .map((entry) => entry.name)
+    .sort();
 
   t.phase("feature writes a spec and stops before implementation");
   const result = t.agent(
@@ -62,13 +81,29 @@ async function run(t: Runner) {
     .git("status", "--porcelain")
     .split("\n")
     .filter(Boolean)
-    .map((line) => line.replace(/^[ MADRCU?!]{1,2}\s+/, ""));
+    .map((line) => line.replace(/^[ MADRCU?!]{1,2}\s+/, ""))
+    .filter((relativePath) => relativePath !== "node_modules/");
 
   t.check("agent invocation succeeded", result.status === 0);
   t.check("a personalized greeting spec was written", /personalized greeting/i.test(currentFeature));
   t.check("the spec has unchecked build steps", currentFeature.includes("- [ ]"));
   t.check("the spec defines observable done-when criteria", /done when/i.test(currentFeature));
   t.check("product source was not edited", t.read("src/greeting.js") === sourceBefore);
+  t.check("package metadata was not edited", t.read("package.json") === packageBefore);
+  t.check(
+    "no dependency installation was added to the spec",
+    !/(?:^|`)[^\S\n]*(?:npm (?:install|i|add)|pnpm (?:add|install)|yarn add|bun add)(?:[^\S\n]+-{1,2}[\w-]+)*[^\S\n]+(?!-)[@\w]/im.test(currentFeature)
+  );
+  t.check(
+    "no top-level directories were added",
+    JSON.stringify(
+      fs
+        .readdirSync(t.workspace, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
+        .map((entry) => entry.name)
+        .sort()
+    ) === JSON.stringify(directoriesBefore)
+  );
   t.check("no implementation branch was created", t.git("branch", "--show-current") === "main");
   t.check("no commit was created", t.git("rev-parse", "HEAD") === headBefore);
   t.check(

--- a/scripts/validate-blueprint.ts
+++ b/scripts/validate-blueprint.ts
@@ -383,6 +383,8 @@ async function validateVerificationContract(): Promise<void> {
         "overview must remain below 20,000 bytes",
         "normalize only build-plan completion markers",
         "without treating completed features as overview drift",
+        "Omit it when the usage-model section",
+        "absent, unanswered, or contains only worksheet prompts",
         "Never create additional generated context files"
       ]
     ],
@@ -426,6 +428,9 @@ async function validateVerificationContract(): Promise<void> {
     [
       ".agents/skills/implement/SKILL.md",
       [
+        "Add an abstraction, dependency, service, configuration surface, compatibility",
+        "only when the approved spec or an established repository requirement needs it now",
+        "Run a proportionality check before final verification",
         "declares a `Verify` command, run that exact",
         "fallback build and tests",
         "verification.logicTests: required",
@@ -458,6 +463,12 @@ async function validateVerificationContract(): Promise<void> {
     [
       ".agents/skills/feature/SKILL.md",
       [
+        "Apply proportional engineering before drafting",
+        "usage-model, data-model, stack, UI, security, or deployment",
+        "Unknown scale or future extensibility defaults to the smaller reversible design",
+        "Treat a trust or data-integrity boundary as established",
+        "Untuned stack-specific standards in `coding-standards.md` are not established requirements",
+        "repository-first tenant scope",
         "Build one authoritative feature packet",
         "Do not read the whole overview by default",
         "Do not invent presets, defaults, limits, permissions",
@@ -487,6 +498,7 @@ async function validateVerificationContract(): Promise<void> {
     [
       ".agents/skills/fix/SKILL.md",
       [
+        "Adding a missing authorization, ownership, validation, escaping, or redaction check",
         "first heading must be exactly",
         "`# Fix: <title>`",
         "`**Type:** Fix` contract"
@@ -495,6 +507,11 @@ async function validateVerificationContract(): Promise<void> {
     [
       ".agents/skills/audit/SKILL.md",
       [
+        "For a proportionality finding, state in **Suggested fix** what can be deleted",
+        "Untuned stack-specific template defaults are not established requirements",
+        "Use `None` when no current requirement would be lost",
+        "An otherwise pure proportionality finding is P2 or P3",
+        "require an explicit user decision and never describe it as an automatic repair",
         "`/audit independent current` is a two-context workflow",
         "Never let a builder complete its own independent request",
         "A stale receipt is no receipt",
@@ -622,12 +639,18 @@ async function validateVerificationContract(): Promise<void> {
         "Claude uses legacy direct context imports",
         "review.independentExecution",
         "Independent review defaults to `when-sensitive`",
-        "defaults to\n     `automatic`"
+        "defaults to\n     `automatic`",
+        "The optional Usage model and constraints section may be blank",
+        "unanswered, or still contain only the shipped worksheet prompts",
+        "unknown and healthy"
       ]
     ],
     [
       ".agents/skills/autopilot/SKILL.md",
       [
+        "Never stop for a reversible internal detail",
+        "only when the approved spec or an established repository requirement needs it now",
+        "does not remove or change shipped behavior",
         "exact `Verify` command from `AGENTS.md`",
         "combines `/feature` or `/fix` with `/implement`",
         "option to walk through the completed code",
@@ -642,6 +665,9 @@ async function validateVerificationContract(): Promise<void> {
     [
       ".agents/skills/continuous/SKILL.md",
       [
+        "Never stop for a reversible internal detail",
+        "only when the approved spec or an established repository requirement needs it now",
+        "does not remove or change shipped behavior",
         "Run the exact documented `Verify` command",
         "one clean local main commit per completed feature",
         "Never push the default branch",
@@ -667,12 +693,24 @@ async function validateVerificationContract(): Promise<void> {
     [
       "AGENTS.md",
       [
+        "## Proportional engineering",
+        "Unknown scale or extensibility defaults to the smaller reversible design",
+        "Derive trust and data-integrity boundaries from actual reachability",
+        "Ask only when an unknown materially changes behavior",
+        "Stack-specific template standards apply only when the project uses that stack",
         "## Automatic verification",
         "`contents: read`",
         "spawns a generic child through the current runtime",
         "never requires or discovers global agent roles",
         "Independent review defaults to `when-sensitive`",
         "Its default, `automatic`"
+      ]
+    ],
+    [
+      "blueprint/project-plan.md",
+      [
+        "## 9. Usage model and constraints (optional)",
+        "Unknown does not mean enterprise, hostile, multi-tenant, or single-user"
       ]
     ],
     [

--- a/scripts/validate-blueprint.ts
+++ b/scripts/validate-blueprint.ts
@@ -354,7 +354,8 @@ async function validateVerificationContract(): Promise<void> {
         "This skill is always optional",
         "Never start it automatically from `/onboard`",
         "Do not write either file in the same response that first presents them",
-        "stop before generating `blueprint/context/project-overview.md`"
+        "stop before generating `blueprint/context/project-overview.md`",
+        "Follow the proportional-engineering contract in `AGENTS.md`"
       ]
     ],
     [
@@ -390,7 +391,10 @@ async function validateVerificationContract(): Promise<void> {
     ],
     [
       ".agents/skills/adopt/SKILL.md",
-      ["Run /ci or $ci when you want automatic GitHub checks."]
+      [
+        "Run /ci or $ci when you want automatic GitHub checks.",
+        "Follow and preserve the proportional-engineering contract in `AGENTS.md`"
+      ]
     ],
     [
       ".agents/skills/ci/SKILL.md",
@@ -640,16 +644,14 @@ async function validateVerificationContract(): Promise<void> {
         "review.independentExecution",
         "Independent review defaults to `when-sensitive`",
         "defaults to\n     `automatic`",
-        "The optional Usage model and constraints section may be blank",
-        "unanswered, or still contain only the shipped worksheet prompts",
-        "unknown and healthy"
+        "Follow the proportional-engineering contract in `AGENTS.md`",
+        "healthy\n     unknown context, not an incomplete requirement"
       ]
     ],
     [
       ".agents/skills/autopilot/SKILL.md",
       [
-        "Never stop for a reversible internal detail",
-        "only when the approved spec or an established repository requirement needs it now",
+        "Follow the proportional-engineering contract in `AGENTS.md` throughout this run",
         "does not remove or change shipped behavior",
         "exact `Verify` command from `AGENTS.md`",
         "combines `/feature` or `/fix` with `/implement`",
@@ -665,8 +667,7 @@ async function validateVerificationContract(): Promise<void> {
     [
       ".agents/skills/continuous/SKILL.md",
       [
-        "Never stop for a reversible internal detail",
-        "only when the approved spec or an established repository requirement needs it now",
+        "Follow the proportional-engineering contract in `AGENTS.md` throughout this run",
         "does not remove or change shipped behavior",
         "Run the exact documented `Verify` command",
         "one clean local main commit per completed feature",
@@ -687,7 +688,8 @@ async function validateVerificationContract(): Promise<void> {
       [
         "Independent review defaults to `when-sensitive`",
         "execution defaults to `automatic`",
-        "disables\nautomatic selection for that workflow without disabling explicit independent\naudits"
+        "disables\nautomatic selection for that workflow without disabling explicit independent\naudits",
+        "Follow and preserve the proportional-engineering contract in `AGENTS.md`"
       ]
     ],
     [


### PR DESCRIPTION
## Summary

Small requirements routinely get inflated into much harder problems during LLM-driven development. An agent may invent assumptions about scale, hostile users, tenancy, compliance, extensibility, or future operations, then encode those assumptions into plans and specifications. Once that speculative complexity reaches a spec, later agents treat it as an approved requirement and add unnecessary abstractions, services, configuration, dependencies, security machinery, and tests.

That inflation also compounds token costs. Overengineered discovery notes, plans, specs, code, tests, review findings, and repair cycles all become context that later agents must repeatedly read and reason about. This PR does not claim a measured percentage reduction, but preventing unnecessary machinery at the planning boundary should reduce generated code and long-term context processing.

Blueprint already controls discovery, specification, implementation, automated execution, and audit, but it did not enforce one consistent proportional-engineering contract across those decision points. A root instruction alone is not enough because Blueprint updates preserve the user's `AGENTS.md` while replacing managed skills.

This change makes proportionality part of the existing workflow without adding a new skill, mandatory questionnaire, complexity score, line budget, dependency, or framework.

1. **Proportional-engineering contract.** `AGENTS.md` now tells agents to avoid unstated requirements, ask only when an unknown materially changes the solution, default unknown scale and extensibility to the smaller reversible design, and reuse repository and platform capabilities before writing custom code. Real trust and data-integrity boundaries visible in the code still apply.

2. **Planning and specification boundaries.** Discovery, Adoption, Overview, Feature, and Fix now preserve confirmed facts and explicit non-requirements without expanding blanks into enterprise assumptions. `project-plan.md` gains an optional usage-model section, and leaving it unanswered is valid. New abstractions, dependencies, services, configuration surfaces, compatibility layers, and specialized security mechanisms require a current requirement.

3. **Proportionate implementation.** Implement, Autopilot, and Continuous Mode reject machinery that is absent from the approved spec or repository evidence. They prefer existing code, the standard library, native platform behavior, and installed dependencies before minimum necessary custom code, while retaining ordinary validation and established security boundaries.

4. **Deletion-focused audits.** Proportionality findings must state what can be removed, what existing or native mechanism replaces it, and which current requirement would be lost. Pure overengineering remains P2 or P3 unless it causes a concrete reachable defect or violates an established security or data-integrity boundary. Removing shipped behavior still requires an explicit user decision.

5. **Focused regression evidence.** Static validation pins only the load-bearing contract clauses. Existing live-agent scenarios now prove that Feature and Autopilot do not introduce dependency changes, unexpected top-level paths, unapproved source changes, premature implementation, completion, or merge behavior.

The contract is repeated only where updated installations and active workflow enforcement require it. Corresponding `.agents/skills/` and `.claude/skills/` changes remain synchronized.

The root README and package README describe the new behavior without duplicating the full contract. `CHANGELOG.md` records it under `Unreleased`.

## Validation

Tested on Windows:

```text
npm run check:static
npm run typecheck
npm run test:package

$env:E2E_ACCEPT_RISK = "1"
$env:E2E_AGENT = "copilot"
npm run test:e2e -- feature-gate autopilot-boundary
```

Results:

- Static Blueprint contract passed: 23 skills, 35 adapter files, 1 Claude import, and 7 skill references.
- TypeScript typecheck passed.
- Packed installer smoke tests passed.
- Live Copilot scenarios passed 22 of 22 checks:
  - `feature-gate`: 11 of 11.
  - `autopilot-boundary`: 11 of 11.
- The dependency-directive matcher passed 12 targeted positive and negative cases covering npm, pnpm, Yarn, Bun, install flags, ordinary prose, and negative instructions.
- No generated `packages/create-ai-blueprint/template/` files were edited manually.
- GitHub's full Validate Blueprint workflow passed against the updated `main` containing #17:
  - Node 22 passed.
  - Node 24 passed.
  - Windows passed.

## Checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Shared skill changes are synchronized across `.agents/skills/` and `.claude/skills/`.
- [x] User-facing workflow behavior is reflected in `AGENTS.md`, both READMEs, and the project-plan worksheet.
- [x] Local focused validation and the full GitHub validation workflow pass.
- [x] No secrets, credentials, private code, or personal data are included.
- [x] Release notes are updated under `Unreleased`; package versioning remains a maintainer release step.