### PR TITLE
fix: make local checkout linking reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 Notable changes to AI Blueprint are documented here. Release dates reflect the
 published `create-ai-blueprint` package.
 
+## [Unreleased]
+
+### Fixed
+
+- Made `npm run link:local` safely repeatable by replacing its existing global
+  package registration before recreating the local link.
+- Kept installers run from a linked source checkout from offering to replace the
+  local commands with the registry package.
+
 ## [1.7.0] - 2026-09-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,12 @@ framework abstractions do not belong in this repository.
 | `npm test` | Run the installer unit tests. |
 | `npm run test:routing` | Run deterministic skill selection cases without invoking an AI agent. |
 | `npm run test:sandbox` | Run deterministic tests for the inspectable scaffold runner. |
+| `npm run test:link-local` | Verify that local linking can safely replace its existing global registration. |
 | `npm run test:package` | Pack the npm artifact and smoke-test individual, combined, default, and legacy adapter installs. |
 | `npm run sandbox` | Scaffold a minimal app, run the local packed Blueprint through its real prompts, verify it, and start its server. |
 | `npm run sandbox:clear` | List every saved sandbox run, ask for confirmation, then delete those runs. |
 | `npm run sandbox:demo` | Run the interactive sandbox with example project and build plans ready for workflow testing. |
-| `npm run link:local` | Build this checkout, prepare its template, and link `create-ai-blueprint` and `blueprint` globally so they run from local files. |
+| `npm run link:local` | Build this checkout, prepare its template, and replace the global `create-ai-blueprint` and `blueprint` commands with links to the local files. |
 | `npm run unlink:local` | Remove the global link created by `npm run link:local`. |
 | `E2E_ACCEPT_RISK=1 npm run test:e2e` | Run all live-agent behavior scenarios in scratch repositories. |
 
@@ -70,7 +71,11 @@ blueprint status
 
 Re-run `npm run link:local` after editing the source. The linked commands run the
 compiled `dist/` output and a copied `template/`, not the source files directly, so
-edits are not picked up until both are rebuilt.
+edits are not picked up until both are rebuilt. Re-running the command removes the
+existing global package registration before recreating the link, so a separate
+`npm run unlink:local` is not required. Installer runs from the linked checkout
+also skip the optional prompt that would replace the local commands with the
+registry package.
 
 `npm run unlink:local` runs `npm rm --global create-ai-blueprint`, which removes any
 global copy of the package, whether it was linked from a checkout or installed from

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:routing": "tsx --test scripts/evals/routing.test.ts && tsx scripts/evals/routing.ts --min-rank1 90",
     "test:sandbox": "tsx --test scripts/scaffold-sandbox.test.ts scripts/clear-sandbox.test.ts",
     "test:activity": "tsx --test scripts/run-state-helper.test.ts",
+    "test:link-local": "tsx --test scripts/link-local.test.ts",
     "test:package": "tsx scripts/smoke-package.ts",
     "test:e2e": "tsx scripts/e2e/run.ts",
     "sandbox": "tsx scripts/scaffold-sandbox.ts",

--- a/packages/create-ai-blueprint/README.md
+++ b/packages/create-ai-blueprint/README.md
@@ -295,11 +295,11 @@ npm install --global create-ai-blueprint@latest
 ```
 
 The prompt defaults to no and is skipped for matching versions, non-interactive
-runs, and `--yes` runs. Accepting it installs or refreshes the CLI at the same
-version used by the npx command. Global installation exposes the shorter forms
-`blueprint status`, `blueprint status --json`, and `blueprint dashboard`. Use
-`--target ./my-app` to inspect an explicit project directory. Status never edits
-project or Git state.
+runs, `--yes` runs, and runs from a source checkout of this repository.
+Accepting it installs or refreshes the CLI at the same version used by the npx
+command. Global installation exposes the shorter forms `blueprint status`,
+`blueprint status --json`, and `blueprint dashboard`. Use `--target ./my-app` to
+inspect an explicit project directory. Status never edits project or Git state.
 
 ## Opening the local dashboard
 

--- a/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
+++ b/packages/create-ai-blueprint/bin/create-ai-blueprint.ts
@@ -850,12 +850,14 @@ async function readCommandOutput(
 
 function shouldOfferGlobalCliInstall(
   options: CliOptions,
-  isTTY: boolean | undefined = process.stdin.isTTY
+  isTTY: boolean | undefined = process.stdin.isTTY,
+  sourceCheckout: boolean = isSourceCheckout()
 ): boolean {
   return (
     (options.command === "install" || options.command === "update") &&
     !options.yes &&
-    isTTY === true
+    isTTY === true &&
+    !sourceCheckout
   );
 }
 
@@ -1018,6 +1020,10 @@ function findPackageRoot(startDir: string): string {
 
     current = parent;
   }
+}
+
+function isSourceCheckout(root: string = packageRoot): boolean {
+  return fsSync.existsSync(path.join(root, "scripts", "prepare-template.ts"));
 }
 
 function formatMissingTemplateMessage(templateRoot: string): string {

--- a/packages/create-ai-blueprint/test/update.test.ts
+++ b/packages/create-ai-blueprint/test/update.test.ts
@@ -194,23 +194,24 @@ test("interactive installs default to Claude Code and Codex", async () => {
   });
 });
 
-test("global CLI installation is offered after interactive installs and updates", () => {
-  assert.equal(shouldOfferGlobalCliInstall(parseArgs([]), true), true);
-  assert.equal(shouldOfferGlobalCliInstall(parseArgs([]), false), false);
+test("global CLI installation is offered for published interactive installs and updates", () => {
+  assert.equal(shouldOfferGlobalCliInstall(parseArgs([]), true), false);
+  assert.equal(shouldOfferGlobalCliInstall(parseArgs([]), true, false), true);
+  assert.equal(shouldOfferGlobalCliInstall(parseArgs([]), false, false), false);
   assert.equal(
-    shouldOfferGlobalCliInstall(parseArgs(["--yes"]), true),
+    shouldOfferGlobalCliInstall(parseArgs(["--yes"]), true, false),
     false
   );
   assert.equal(
-    shouldOfferGlobalCliInstall(parseArgs(["update"]), true),
+    shouldOfferGlobalCliInstall(parseArgs(["update"]), true, false),
     true
   );
   assert.equal(
-    shouldOfferGlobalCliInstall(parseArgs(["update"]), false),
+    shouldOfferGlobalCliInstall(parseArgs(["update"]), false, false),
     false
   );
   assert.equal(
-    shouldOfferGlobalCliInstall(parseArgs(["update", "--yes"]), true),
+    shouldOfferGlobalCliInstall(parseArgs(["update", "--yes"]), true, false),
     false
   );
   assert.equal(isGlobalCliInstallConfirmed("y"), true);

--- a/scripts/check-blueprint.ts
+++ b/scripts/check-blueprint.ts
@@ -28,6 +28,10 @@ const checks: CheckCommand[] = [
     ...npmInvocation(["run", "test:activity"])
   },
   {
+    name: "Local link regression test",
+    ...npmInvocation(["run", "test:link-local"])
+  },
+  {
     name: "Installer unit tests",
     ...npmInvocation(["--prefix", "packages/create-ai-blueprint", "test"])
   },

--- a/scripts/link-local.test.ts
+++ b/scripts/link-local.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packageRoot = path.join(repoRoot, "packages", "create-ai-blueprint");
+
+test("link:local can replace its existing global link", { timeout: 300_000 }, async () => {
+  const prefix = await fs.mkdtemp(path.join(os.tmpdir(), "blueprint-local-link-"));
+
+  try {
+    const first = runNpm(prefix, ["run", "link:local"]);
+    assert.equal(first.status, 0, formatFailure(first));
+
+    const second = runNpm(prefix, ["run", "link:local"]);
+    assert.equal(second.status, 0, formatFailure(second));
+
+    const npmRoot = runNpm(prefix, ["root", "--global"]);
+    assert.equal(npmRoot.status, 0, formatFailure(npmRoot));
+    assert.equal(
+      await canonicalPath(path.join(npmRoot.stdout.trim(), "create-ai-blueprint")),
+      await canonicalPath(packageRoot)
+    );
+
+    const binRoot = process.platform === "win32" ? prefix : path.join(prefix, "bin");
+    const suffix = process.platform === "win32" ? ".cmd" : "";
+    await Promise.all(
+      ["create-ai-blueprint", "blueprint"].map((name) =>
+        fs.access(path.join(binRoot, `${name}${suffix}`))
+      )
+    );
+  } finally {
+    await fs.rm(prefix, { recursive: true, force: true });
+  }
+});
+
+function runNpm(prefix: string, args: string[]) {
+  const npmExecPath = process.env.npm_execpath;
+  assert.ok(npmExecPath, "npm_execpath is required to run the local-link integration test.");
+
+  return spawnSync(process.execPath, [npmExecPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      npm_config_audit: "false",
+      npm_config_fund: "false",
+      npm_config_prefix: prefix,
+      npm_config_update_notifier: "false"
+    },
+    maxBuffer: 64 * 1024 * 1024
+  });
+}
+
+async function canonicalPath(target: string): Promise<string> {
+  const resolved = await fs.realpath(target);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function formatFailure(result: ReturnType<typeof runNpm>): string {
+  return [result.stdout, result.stderr, result.error?.message].filter(Boolean).join("\n");
+}

--- a/scripts/link-local.ts
+++ b/scripts/link-local.ts
@@ -72,6 +72,7 @@ function main(): void {
 
   runNpm(["run", "build"]);
   runNpm(["run", "prepare-template"]);
+  runNpm(["rm", "--global", packageName]);
   runNpm(["link"]);
 
   console.log(`

--- a/scripts/smoke-package.ts
+++ b/scripts/smoke-package.ts
@@ -134,6 +134,9 @@ async function main(): Promise<void> {
       "node_modules",
       "create-ai-blueprint"
     );
+    await requireMissing(
+      path.join(installedPackageRoot, "scripts", "prepare-template.ts")
+    );
     const binary = path.join(installedPackageRoot, "dist", "bin", "create-ai-blueprint.js");
     const metadata = parseRecord(
       await fs.readFile(path.join(installedPackageRoot, "package.json"), "utf8"),


### PR DESCRIPTION
## Summary

Local-checkout development currently has two related failure modes.

First, running `npm run link:local` more than once can fail under npm 12 with an `EEXIST` error when npm tries to recreate the existing global command shims. Contributors must manually run `npm run unlink:local` before every relink, which makes the documented local-development loop unnecessarily fragile.

Second, when `create-ai-blueprint` runs from a locally linked source checkout, the installer can offer to install the published registry CLI globally. Accepting that prompt replaces the locally linked commands with the upstream package, silently switching the contributor away from the code they are testing.

This PR addresses both behaviors:

1. **Make `link:local` repeatable.** The command now builds the installer and prepares its template before removing the existing global `create-ai-blueprint` registration and recreating the link. This refreshes the package registration and command shims without requiring a separate unlink command or using npm's broader `--force` option.

2. **Preserve source-checkout CLI links.** Installer runs from a source checkout no longer offer to install the published global CLI. Source checkouts are identified by `scripts/prepare-template.ts`, which is present in the repository but excluded from the published package. Published interactive installs and updates retain the existing prompt.

3. **Add regression coverage.** A temporary-prefix integration test runs `npm run link:local` twice and verifies that both runs succeed, the global package resolves to the current checkout, and both `create-ai-blueprint` and `blueprint` command shims exist. The packed-package smoke test also proves that the source-checkout marker is absent from published artifacts.

The local-link regression test is part of the repository's full validation gate. Contributor documentation, package documentation, and the changelog describe the updated behavior.

Implementation notes:

- The build and template preparation complete before the existing global registration is removed, reducing the chance of leaving the contributor without a working command after an earlier preparation failure.
- `npm rm --global create-ai-blueprint` intentionally replaces either an existing local link or a registry-installed copy because the purpose of `link:local` is to activate the current checkout.
- Historical command shims from hypothetical past `bin` names are not cleaned up. The current command names are stable, and adding manifest-history handling would be disproportionate to the reported issue.

## Validation

```text
git diff --check
npm run check
```

Both passed locally on Windows.

The full gate covered:

- TypeScript typechecking.
- Static Blueprint contract validation.
- Skill routing evaluations.
- Sandbox runner tests.
- Dashboard activity helper tests.
- Installer unit tests, including published-package and source-checkout prompt behavior.
- The repeatable local-link regression test under an isolated temporary npm prefix.
- Packed installer smoke tests, including confirmation that the source-checkout marker is not published.

## Checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Shared skill changes are synchronized across `.agents/skills/` and `.claude/skills/`. Not applicable; no skill files changed.
- [x] User-facing behavior is reflected in the root and package documentation where needed.
- [x] `npm run check` passes locally.
- [x] No secrets, credentials, private code, or personal data are included.
- [x] Package version and release notes are updated when the change is intended for publication. Added release notes under `Unreleased`; the package version remains a maintainer release step.